### PR TITLE
이미지 업로드를 위한 Input Box 구현

### DIFF
--- a/libs/shared/input-select-btn/feature/feature-image-input.tsx
+++ b/libs/shared/input-select-btn/feature/feature-image-input.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React, { useRef, useState } from 'react'
+
+import UiAddImageBtn from '@/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn'
+import UiImageInput from '@/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input'
+
+export default function ImageInput({
+  title,
+  preSelectedImageUrl = undefined,
+}: {
+  title: string
+  preSelectedImageUrl?: string
+}) {
+  const [selectedImage, setSelectedImage] = useState<string>('')
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleImage = (file: File) => {
+    // 수정 필요. css 적용 때문에 미리보이게 함
+    if (file && file.type.startsWith('image/')) {
+      const reader = new FileReader()
+
+      reader.onload = () => {
+        if (reader.result) {
+          setSelectedImage(reader.result.toString())
+        }
+      }
+
+      reader.readAsDataURL(file)
+    }
+    // presignedURL 가져오는 uploadImage request로 변경
+    // setSelectedImage('presignedURL')
+    // preSelectedImageUrl
+  }
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    const file = e.dataTransfer.files[0]
+    handleImage(file)
+  }
+
+  const handleButtonClick = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click()
+    }
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    console.log(file)
+    if (file) {
+      handleImage(file)
+    }
+  }
+
+  return (
+    <UiImageInput
+      handleDrop={handleDrop}
+      handleButtonClick={handleButtonClick}
+      handleInputChange={handleInputChange}
+      selectedImage={selectedImage}
+      title={title}
+      ref={fileInputRef}
+    >
+      <UiAddImageBtn
+        onClickAddImageButton={handleButtonClick}
+        preSelectedImageUrl={preSelectedImageUrl}
+      />
+    </UiImageInput>
+  )
+}

--- a/libs/shared/input-select-btn/feature/feature-image-input.tsx
+++ b/libs/shared/input-select-btn/feature/feature-image-input.tsx
@@ -7,10 +7,10 @@ import UiImageInput from '@/libs/shared/input-select-btn/ui/ui-image-input/ui-im
 
 export default function ImageInput({
   title,
-  preSelectedImageUrl = undefined,
+  preselectedImageUrl = undefined,
 }: {
   title: string
-  preSelectedImageUrl?: string
+  preselectedImageUrl?: string
 }) {
   const [selectedImage, setSelectedImage] = useState<string>('')
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -30,22 +30,22 @@ export default function ImageInput({
     }
     // presignedURL 가져오는 uploadImage request로 변경
     // setSelectedImage('presignedURL')
-    // preSelectedImageUrl
+    // preselectedImageUrl
   }
 
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+  const handleDropImage = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault()
     const file = e.dataTransfer.files[0]
     handleImage(file)
   }
 
-  const handleButtonClick = () => {
+  const handleClickButton = () => {
     if (fileInputRef.current) {
       fileInputRef.current.click()
     }
   }
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     console.log(file)
     if (file) {
@@ -55,16 +55,16 @@ export default function ImageInput({
 
   return (
     <UiImageInput
-      handleDrop={handleDrop}
-      handleButtonClick={handleButtonClick}
-      handleInputChange={handleInputChange}
+      onDropImgae={handleDropImage}
+      onClickButton={handleClickButton}
+      onChangeInput={handleChangeInput}
       selectedImage={selectedImage}
       title={title}
       ref={fileInputRef}
     >
       <UiAddImageBtn
-        onClickAddImageButton={handleButtonClick}
-        preSelectedImageUrl={preSelectedImageUrl}
+        onClickAddImageButton={handleClickButton}
+        preselectedImageUrl={preselectedImageUrl}
       />
     </UiImageInput>
   )

--- a/libs/shared/input-select-btn/types-input-select-btn.d.ts
+++ b/libs/shared/input-select-btn/types-input-select-btn.d.ts
@@ -16,3 +16,12 @@ interface Valid {
   valid: string
   isValid: boolean
 }
+
+interface UiImageInputProps {
+  title: string
+  selectedImage: string
+  handleDrop: (e: React.DragEvent<HTMLDivElement>) => void
+  handleButtonClick: () => void
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  children: React.ReactNode
+}

--- a/libs/shared/input-select-btn/types-input-select-btn.d.ts
+++ b/libs/shared/input-select-btn/types-input-select-btn.d.ts
@@ -20,8 +20,8 @@ interface Valid {
 interface UiImageInputProps {
   title: string
   selectedImage: string
-  handleDrop: (e: React.DragEvent<HTMLDivElement>) => void
-  handleButtonClick: () => void
-  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onDropImgae: (e: React.DragEvent<HTMLDivElement>) => void
+  onClickButton: () => void
+  onChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => void
   children: React.ReactNode
 }

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.module.scss
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.module.scss
@@ -1,0 +1,47 @@
+@use '@/styles/utils';
+
+.addButton {
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  width: 483px;
+  height: 276px;
+  border: 1px solid utils.$gray-brt3;
+  border-radius: 12px;
+  background-color: utils.$gray-brt5;
+}
+
+.preSelectedImage {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: brightness(0.5);
+  border-radius: 12px;
+}
+
+.buttonContent {
+  @include utils.flexbox(column, center, center);
+
+  position: absolute;
+  inset: 0;
+  gap: 11px;
+}
+
+.camera {
+  &.preSelectedImageUrl {
+    filter: brightness(0%) invert(100%);
+  }
+}
+
+.addImageText {
+  color: utils.$gray-brt2;
+  @include utils.font-style('body1Bold');
+
+  line-height: 20px;
+
+  &.preSelectedImageUrl {
+    color: utils.$white;
+  }
+}

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.module.scss
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.module.scss
@@ -30,7 +30,7 @@
 }
 
 .camera {
-  &.preSelectedImageUrl {
+  &.preselectedImageUrl {
     filter: brightness(0%) invert(100%);
   }
 }
@@ -41,7 +41,7 @@
 
   line-height: 20px;
 
-  &.preSelectedImageUrl {
+  &.preselectedImageUrl {
     color: utils.$white;
   }
 }

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.tsx
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.tsx
@@ -1,0 +1,44 @@
+import classNames from 'classnames/bind'
+
+import Image from 'next/image'
+
+import styles from './ui-add-image-btn.module.scss'
+
+const cx = classNames.bind(styles)
+
+export default function UiAddImageBtn({
+  onClickAddImageButton,
+  preSelectedImageUrl,
+}: {
+  onClickAddImageButton: () => void
+  preSelectedImageUrl?: string
+}) {
+  const buttonType = preSelectedImageUrl ? '변경' : '추가'
+  return (
+    <button
+      type="button"
+      onClick={onClickAddImageButton}
+      className={cx('addButton')}
+    >
+      {preSelectedImageUrl && (
+        <img
+          alt="예전에 선택한 이미지"
+          className={cx('preSelectedImage')}
+          src={preSelectedImageUrl}
+        />
+      )}
+      <div className={cx('buttonContent')}>
+        <Image
+          src="/images/camera.svg"
+          alt="이미지 추가하기 버튼 카메라 아이콘"
+          width={32}
+          height={32}
+          className={cx('camera', { preSelectedImageUrl })}
+        />
+        <div className={cx('addImageText', { preSelectedImageUrl })}>
+          이미지 {buttonType}하기
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.tsx
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.tsx
@@ -8,23 +8,23 @@ const cx = classNames.bind(styles)
 
 export default function UiAddImageBtn({
   onClickAddImageButton,
-  preSelectedImageUrl,
+  preselectedImageUrl,
 }: {
   onClickAddImageButton: () => void
-  preSelectedImageUrl?: string
+  preselectedImageUrl?: string
 }) {
-  const buttonType = preSelectedImageUrl ? '변경' : '추가'
+  const buttonType = preselectedImageUrl ? '변경' : '추가'
   return (
     <button
       type="button"
       onClick={onClickAddImageButton}
       className={cx('addButton')}
     >
-      {preSelectedImageUrl && (
+      {preselectedImageUrl && (
         <img
           alt="예전에 선택한 이미지"
           className={cx('preSelectedImage')}
-          src={preSelectedImageUrl}
+          src={preselectedImageUrl}
         />
       )}
       <div className={cx('buttonContent')}>
@@ -33,9 +33,9 @@ export default function UiAddImageBtn({
           alt="이미지 추가하기 버튼 카메라 아이콘"
           width={32}
           height={32}
-          className={cx('camera', { preSelectedImageUrl })}
+          className={cx('camera', { preselectedImageUrl })}
         />
-        <div className={cx('addImageText', { preSelectedImageUrl })}>
+        <div className={cx('addImageText', { preselectedImageUrl })}>
           이미지 {buttonType}하기
         </div>
       </div>

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.module.scss
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.module.scss
@@ -1,0 +1,43 @@
+@use '@/styles/utils';
+
+.wrap {
+  @include utils.flexbox(column, start, start);
+
+  gap: 8px;
+}
+
+.title {
+  @include utils.font-style('body1');
+
+  line-height: 26px;
+}
+
+.imgWrap {
+  width: 483px;
+  height: 276px;
+  border-radius: 12px;
+}
+
+.buttonContent {
+  @include utils.flexbox(column, center, center);
+
+  gap: 11px;
+}
+
+.addImageText {
+  color: utils.$gray-brt2;
+  @include utils.font-style('body1Bold');
+
+  line-height: 20px;
+}
+
+.preImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.input {
+  display: none;
+}

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.tsx
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.tsx
@@ -8,9 +8,10 @@ const cx = classNames.bind(styles)
 
 export default forwardRef(function UiImageInput(
   {
-    handleDrop,
-    handleButtonClick,
-    handleInputChange,
+    onDropImgae,
+    onClickButton,
+    onChangeInput,
+
     title,
     selectedImage,
     children,
@@ -21,15 +22,11 @@ export default forwardRef(function UiImageInput(
     <div
       className={cx('wrap')}
       onDragOver={(e) => e.preventDefault()}
-      onDrop={handleDrop}
+      onDrop={onDropImgae}
     >
       <div className={cx('title')}>{title}</div>
       {selectedImage ? (
-        <button
-          type="button"
-          onClick={handleButtonClick}
-          className={cx('imgWrap')}
-        >
+        <button type="button" onClick={onClickButton} className={cx('imgWrap')}>
           <img
             src={selectedImage}
             alt="선택된 이미지"
@@ -42,7 +39,7 @@ export default forwardRef(function UiImageInput(
       <input
         type="file"
         accept="image/*"
-        onChange={handleInputChange}
+        onChange={onChangeInput}
         ref={ref}
         className={cx('input')}
       />

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.tsx
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.tsx
@@ -1,0 +1,51 @@
+import { ForwardedRef, forwardRef } from 'react'
+
+import classNames from 'classnames/bind'
+
+import styles from './ui-image-input.module.scss'
+
+const cx = classNames.bind(styles)
+
+export default forwardRef(function UiImageInput(
+  {
+    handleDrop,
+    handleButtonClick,
+    handleInputChange,
+    title,
+    selectedImage,
+    children,
+  }: UiImageInputProps,
+  ref: ForwardedRef<HTMLInputElement>,
+) {
+  return (
+    <div
+      className={cx('wrap')}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+    >
+      <div className={cx('title')}>{title}</div>
+      {selectedImage ? (
+        <button
+          type="button"
+          onClick={handleButtonClick}
+          className={cx('imgWrap')}
+        >
+          <img
+            src={selectedImage}
+            alt="선택된 이미지"
+            className={cx('preImage')}
+          />
+        </button>
+      ) : (
+        children
+      )}
+      <input
+        type="file"
+        accept="image/*"
+        onChange={handleInputChange}
+        ref={ref}
+        className={cx('input')}
+      />
+    </div>
+  )
+})


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선


## 설명
이미지 업로드 시 필요한 input-box 구현
api 로직을 제외한 파일 업로드, 미리보기가 가능합니다.
현재 구현되어있는 미리보기는 추후 presigned로 변경될 예정입니다.


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #42 

### Key Changes

- ui-image-input : 가게 등록, 가게 편집에 따라 미리 선택되어있는 이미지 유무가 달라집니다.
- ui-add-image-btn : 이미지 유무에 따라 버튼 배경이 사진인지, 회색인지 달라집니다.
- feature-image-input : 편집이라면 props로 원래 가게의 이미지를 넘겨줘야합니다.

### How it Works
feature-image-input의 props로 title과 preSelectedImageUrl을 받습니다.
가게 등록의 경우 title만 넘기면 되고, 가게 편집의 경우 원래 가게의 이미지 url인 preSelectedImageUrl를 넘겨줍니다.


### To Reviewers
