### PR TITLE
공통 컴포넌트 - Notice-card 스타일 수정

### DIFF
--- a/libs/shared/notice-card/data-access/data-access-mock.ts
+++ b/libs/shared/notice-card/data-access/data-access-mock.ts
@@ -5,7 +5,7 @@ const MOCK_DOMAIN = {
 const MOCK_NOTICES = [
   {
     name: '성경만두0',
-    duration: '2023-01-03 15:00~ 18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
+    duration: '2023-01-03 15:00~18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
     workhour: 3,
     address: '서울시 종로구', // address1에 나와 있는 것들
     hourlyPay: 9500,
@@ -16,7 +16,7 @@ const MOCK_NOTICES = [
   },
   {
     name: '성경만두',
-    duration: '2023-01-03 15:00~ 18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
+    duration: '2023-01-03 15:00~18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
     workhour: 3,
     address: '서울시 종로구', // address1에 나와 있는 것들
     hourlyPay: 18000,
@@ -27,7 +27,7 @@ const MOCK_NOTICES = [
   },
   {
     name: '성경만두2',
-    duration: '2023-01-03 15:00~ 18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
+    duration: '2023-01-03 15:00~18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
     workhour: 3,
     address: '서울시 종로구', // address1에 나와 있는 것들
     hourlyPay: 9500,
@@ -38,7 +38,7 @@ const MOCK_NOTICES = [
   },
   {
     name: '성경만두3',
-    duration: '2023-01-03 15:00~ 18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
+    duration: '2023-01-03 15:00~18:00', // startsAt + workhour를 활용해서 이 형식으로 변환해야 한다.
     workhour: 3,
     address: '서울시 종로구', // address1에 나와 있는 것들
     hourlyPay: 9500,
@@ -54,7 +54,7 @@ const MOCK_NOTICES = [
       <UiNoticeDetailCard
         name="성경만두4"
         imageUrl="https://bootcamp-project-api.s3.ap-northeast-2.amazonaws.com/0-1/the-julge/d3fdf139-8b17-46ac-8e72-9ceb9893ae68-xef.jpeg"
-        duration="2023-01-03 15:00~ 18:00"
+        duration="2023-01-03 15:00~18:00"
         workhour={3}
         address="서울시 종로구"
         closed={false}

--- a/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-chip.module.scss
+++ b/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-chip.module.scss
@@ -29,10 +29,11 @@
 
   .chipText {
     color: utils.$white;
+    font-size: 12px;
     font-style: normal;
+    font-weight: 700;
     line-height: normal;
     text-align: center;
-    @include utils.font-style('body2Bold');
   }
 
   .imgContainer {

--- a/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.module.scss
+++ b/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.module.scss
@@ -195,7 +195,8 @@
             flex: 1 0 0;
             flex-direction: column;
             justify-content: center;
-            line-height: 100%;
+            line-height: 16px;
+            word-break: keep-all;
           }
         }
 

--- a/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.module.scss
+++ b/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.module.scss
@@ -1,48 +1,58 @@
 @use '@/styles/utils';
 
+$card-size-large: 312px;
+$card-size-small: 171px;
+
 .wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  @include utils.flexbox(column, flex-start, flex-start);
+
   max-width: 964px;
   gap: 32px;
 
-  .titleHeader {
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-
-    .title {
-      width: 100%;
-      color: utils.$black;
-      font-size: 28px;
-      font-style: normal;
-      font-weight: 700;
-      letter-spacing: 0.56px;
-      line-height: normal;
-    }
-  }
-
-  .listWrapper {
-    display: flex;
-    flex-wrap: wrap;
-    width: 100%;
-    gap: 31px 14px;
+  @include utils.mobile {
+    gap: 16px;
   }
 }
 
-@include utils.mobile {
-  .wrapper {
-    gap: 16px;
+.titleHeader {
+  @include utils.flexbox(row, space-between, flex-start);
 
-    .titleHeader {
-      .title {
-        font-size: 20px;
-      }
-    }
+  width: 100%;
 
-    .listWrapper {
-      gap: 16px 8px;
-    }
+  @include utils.mobile {
+    @include utils.flexbox(column, flex-start, flex-start);
+  }
+}
+
+.title {
+  color: utils.$black;
+  font-size: 28px;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.56px;
+  line-height: normal;
+
+  @include utils.mobile {
+    font-size: 20px;
+  }
+}
+
+.listWrapper {
+  display: grid;
+  grid-template-columns: repeat(3, $card-size-large);
+  margin: 0 auto;
+  gap: 31px 14px;
+
+  @include utils.tablet-card-wrap {
+    grid-template-columns: repeat(2, $card-size-large);
+  }
+
+  @include utils.mobile {
+    grid-template-columns: repeat(3, $card-size-small);
+    gap: 16px 8px;
+  }
+
+  @include utils.mobile-card-wrap {
+    grid-template-columns: repeat(2, $card-size-small);
   }
 }

--- a/styles/_mixin.scss
+++ b/styles/_mixin.scss
@@ -2,8 +2,10 @@
 @use 'sass:list';
 
 // 반응형
-$breakpoint-mobile: 768px;
 $breakpoint-tablet: 1200px;
+$breakpoint-mobile: 768px;
+$breakpoint-tablet-card-wrap: 1028px;
+$breakpoint-mobile-card-wrap: 593px;
 
 @mixin tablet {
   @media (max-width: #{$breakpoint-tablet}) {
@@ -13,6 +15,18 @@ $breakpoint-tablet: 1200px;
 
 @mixin mobile {
   @media (max-width: #{$breakpoint-mobile}) {
+    @content;
+  }
+}
+
+@mixin tablet-card-wrap {
+  @media (max-width: #{$breakpoint-tablet-card-wrap}) {
+    @content;
+  }
+}
+
+@mixin mobile-card-wrap {
+  @media (max-width: #{$breakpoint-mobile-card-wrap}) {
     @content;
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FIX : 버그 수정
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- STYLE : 코드 스타일에 관련된 변경 사항

## 설명

notice-card 내 컴포넌트 들의 스타일을 수정

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

### Key Changes

- 카드 wrap 미디어 분기 추가 설정
    - tablet, mobile에서 카드가 wrap 되는 미디어 분기 추가로 넣었습니다.
- card-list grid로 변경
- 기간 텍스트 줄 높이, 줄넘김 속성 변경
- chip 사이즈 축소


### How it Works

- 기존의 미디어 분기와 card가 wrap 되는 상황이 서로 어색하게 매치되어 미디어 분기를 추가로 설정했습니다. 미디어 분기 별로 레이아웃은 아래와 같이 보입니다.

### 미디어 분기 별 레이아웃 형태

- 1028px($breakpoint-tablet-card-wrap) 이상

![image](https://github.com/codeit-bootcamp-frontend/0-the-julge-young-developers/assets/125791542/4df6610f-ad00-4e22-82b5-e184528dcdef)

- 768px ~ 1028px

![image](https://github.com/codeit-bootcamp-frontend/0-the-julge-young-developers/assets/125791542/102e9c90-e003-49ef-b73f-5703da4b6301)

- 593px($breakpoint-mobile-card-wrap) ~ 768px

![image](https://github.com/codeit-bootcamp-frontend/0-the-julge-young-developers/assets/125791542/5ff7f277-1382-4bdd-ab0d-fb98acbaf5d8)

- 593px 미만

![image](https://github.com/codeit-bootcamp-frontend/0-the-julge-young-developers/assets/125791542/d8dd90d7-b0ab-40ca-af9e-4a06776067e9)

- NoticeCardItem feature는 아래처럼 사용하면 될 것 같습니다 @Andy-Shin99 
- 그리고 카드가 들어있는 `사장의 가게 정보 상세나 `알바의 공고 상세`에도 카드 레이아웃을 동일하게 적용하기 떄문에 페이지 나머지 반쪽에 들어있는 컨텐츠도 width를 동일하게 바꿔주면 됩니다.

```ts
<div className={cx('wrapper')}>
    <NoticeCardItem />
</div>

.wrapper {
  max-width: 964px;
  margin: 60px auto;

  @include utils.tablet-card-wrap {
    padding-right: 32px;
    padding-left: 32px;
  }
}
```

### To Reviewers

- 코드잇에서 여러분과 직접 얘기하면서 바꾼 레이아웃이라 결정하는 회의는 따로 없이 일단 PR 올리겠습니다.
