### PR TITLE
🚑 공고 상세 카드 스타일 수정 및 타입 분리

### DIFF
--- a/libs/shared/notice-card/type-notice-card.ts
+++ b/libs/shared/notice-card/type-notice-card.ts
@@ -1,0 +1,45 @@
+const CARD_CHIPS = {
+  Red: 'red',
+  Orange: 'orange',
+  Hide: 'hide',
+} as const
+export type CardChips = (typeof CARD_CHIPS)[keyof typeof CARD_CHIPS]
+
+export interface UiNoticeCardChipProps {
+  isCardItem?: boolean
+  isShowChip: CardChips
+  changeRate: undefined | number
+  closed: boolean
+}
+
+export interface UiNoticeDetailCardProps {
+  name: string
+  imageUrl: string
+  duration: string
+  workhour: number
+  address: string
+  closed: boolean
+  description: string
+  hourlyPay: number
+  originalHourlyPay: number
+  children: React.ReactNode
+}
+
+export interface UiNoticeCardItemProps {
+  name: string
+  duration: string
+  workhour: number
+  address: string
+  hourlyPay: number
+  imageUrl: string
+  closed: boolean
+  changeRate: undefined | number
+  isShowChip: CardChips
+  handleClickToDetail: () => void
+}
+
+export interface UiNoticeCardListProps {
+  title: string
+  filterElement?: React.ReactNode
+  children: React.ReactNode
+}

--- a/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-chip.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-chip.tsx
@@ -3,19 +3,12 @@ import classNames from 'classnames/bind'
 
 import Image from 'next/image'
 
+import { UiNoticeCardChipProps } from '@/libs/shared/notice-card/type-notice-card'
 import { chipText } from '@/libs/shared/notice-card/util/util-calc-chip-text'
-import { CardChips } from '@/libs/shared/notice-card/util/util-calc-pay-diff'
 
 import styles from './ui-notice-card-chip.module.scss'
 
 const cx = classNames.bind(styles)
-
-interface UiNoticeCardChipProps {
-  isCardItem?: boolean
-  isShowChip: CardChips
-  changeRate: undefined | number
-  closed: boolean
-}
 
 export default function UiNoticeCardChip({
   isCardItem,

--- a/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.tsx
@@ -3,25 +3,12 @@ import classNames from 'classnames/bind'
 
 import Image from 'next/image'
 
-import { CardChips } from '@/libs/shared/notice-card/util/util-calc-pay-diff'
+import { UiNoticeCardItemProps } from '@/libs/shared/notice-card/type-notice-card'
 
 import UiNoticeCardChip from './ui-notice-card-chip'
 import styles from './ui-notice-card-item.module.scss'
 
 const cx = classNames.bind(styles)
-
-interface UiNoticeCardItemProps {
-  name: string
-  duration: string
-  workhour: number
-  address: string
-  hourlyPay: number
-  imageUrl: string
-  closed: boolean
-  changeRate: undefined | number
-  isShowChip: CardChips
-  handleClickToDetail: () => void
-}
 
 export default function UiNoticeCardItem({
   name,

--- a/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.tsx
@@ -4,15 +4,11 @@ import { ForwardedRef, forwardRef } from 'react'
 
 import classNames from 'classnames/bind'
 
+import { UiNoticeCardListProps } from '@/libs/shared/notice-card/type-notice-card'
+
 import styles from './ui-notice-card-list.module.scss'
 
 const cx = classNames.bind(styles)
-
-interface UiNoticeCardListProps {
-  title: string
-  filterElement?: React.ReactNode
-  children: React.ReactNode
-}
 
 export default forwardRef(function UiNoticeCardList(
   { title, filterElement, children }: UiNoticeCardListProps,

--- a/libs/shared/notice-card/ui/ui-notice-detail-card/ui-notice-detail-card.module.scss
+++ b/libs/shared/notice-card/ui/ui-notice-detail-card/ui-notice-detail-card.module.scss
@@ -159,14 +159,20 @@
 
 @include utils.tablet {
   .detailCardWrapper {
-    flex-direction: column;
-    flex-shrink: 0;
-    width: 680px;
+    @include utils.flexbox(column, flex-start, flex-start);
+
+    width: 100%;
 
     .imgContainer {
-      --img-width: 632px;
-      --img-height: 360px;
-      --img-border-radius: 12px;
+      width: 100%;
+      height: auto;
+      aspect-ratio: 1.75/1;
+
+      .closedLayer {
+        width: 100%;
+        height: auto;
+        aspect-ratio: 1.75/1;
+      }
     }
 
     .card {
@@ -179,14 +185,7 @@
 
 @include utils.mobile {
   .detailCardWrapper {
-    width: 351px;
     padding: 20px;
-
-    .imgContainer {
-      --img-width: 311px;
-      --img-height: 178px;
-      --img-border-radius: 12px;
-    }
 
     .card {
       padding-top: 12px;

--- a/libs/shared/notice-card/ui/ui-notice-detail-card/ui-notice-detail-card.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-detail-card/ui-notice-detail-card.tsx
@@ -76,7 +76,6 @@ export default function UiNoticeDetailCard({
           </div>
           <p className={cx('address', { closed })}>{address}</p>
         </div>
-
         <p className={cx('description')}>{description}</p>
         <div className={cx('btnWrapper')}>{children}</div>
       </div>

--- a/libs/shared/notice-card/ui/ui-notice-detail-card/ui-notice-detail-card.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-detail-card/ui-notice-detail-card.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 import classNames from 'classnames/bind'
 
+import { UiNoticeDetailCardProps } from '@/libs/shared/notice-card/type-notice-card'
 import UiNoticeCardChip from '@/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-chip'
 import { utilCalcChangeRate } from '@/libs/shared/notice-card/util/util-calc-change-rate'
 import { utilCalcPayDiff } from '@/libs/shared/notice-card/util/util-calc-pay-diff'
@@ -8,19 +9,6 @@ import { utilCalcPayDiff } from '@/libs/shared/notice-card/util/util-calc-pay-di
 import styles from './ui-notice-detail-card.module.scss'
 
 const cx = classNames.bind(styles)
-
-interface UiNoticeDetailCardProps {
-  name: string
-  imageUrl: string
-  duration: string
-  workhour: number
-  address: string
-  closed: boolean
-  description: string
-  hourlyPay: number
-  originalHourlyPay: number
-  children: React.ReactNode
-}
 
 export default function UiNoticeDetailCard({
   name,

--- a/libs/shared/notice-card/util/util-calc-chip-text.ts
+++ b/libs/shared/notice-card/util/util-calc-chip-text.ts
@@ -1,4 +1,4 @@
-import { CardChips } from './util-calc-pay-diff'
+import { CardChips } from '@/libs/shared/notice-card/type-notice-card'
 
 const chipText = (chip: CardChips, rate: undefined | number) => {
   if (chip === 'red' || chip === 'orange') {

--- a/libs/shared/notice-card/util/util-calc-pay-diff.ts
+++ b/libs/shared/notice-card/util/util-calc-pay-diff.ts
@@ -1,9 +1,4 @@
-const CARD_CHIPS = {
-  Red: 'red',
-  Orange: 'orange',
-  Hide: 'hide',
-} as const
-export type CardChips = (typeof CARD_CHIPS)[keyof typeof CARD_CHIPS]
+import { CardChips } from '@/libs/shared/notice-card/type-notice-card'
 
 const utilCalcPayDiff = (
   currentPay: number,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- STYLE : 코드 스타일에 관련된 변경 사항

## 설명

공고 상세 카드 스타일 수정 및 타입 분리

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #98 

### Key Changes

- 공고 상세 카드의 스타일을 tablet 버전부터 width 100%가 되도록 수정 (쓰는 쪽에선 변화 없음)
- notice-card 도메인의 타입들을 별도 파일로 분리


### How it Works

- 간단한 로직 설명


### To Reviewers

- 애매하거나 같이 얘기해보고 싶은 부분
