### PR TITLE
가게 등록 모달 PC 컴포넌트 제작

### DIFF
--- a/libs/my-shop-eva/feature/feature-register-shop-modal-default-content.module.scss
+++ b/libs/my-shop-eva/feature/feature-register-shop-modal-default-content.module.scss
@@ -19,3 +19,9 @@
 .textAreaContainer {
   width: 100%;
 }
+
+.button {
+  width: 312px;
+  height: 48px;
+  margin: 0 auto;
+}

--- a/libs/my-shop-eva/feature/feature-register-shop-modal-default-content.module.scss
+++ b/libs/my-shop-eva/feature/feature-register-shop-modal-default-content.module.scss
@@ -1,0 +1,21 @@
+@use '@/styles/utils';
+
+.contentWrap {
+  @include utils.flexbox(column, center, flex-start);
+
+  width: 100%;
+  margin: 32px 0;
+  gap: 24px;
+}
+
+.inputContainer {
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: repeat(2, 1fr);
+  align-items: center;
+  width: 100%;
+}
+
+.textAreaContainer {
+  width: 100%;
+}

--- a/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
+++ b/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
@@ -1,5 +1,13 @@
+'use client'
+
+import { ChangeEvent, useEffect, useState } from 'react'
+
 import classNames from 'classnames/bind'
 
+import {
+  ActiveBtn,
+  InactiveBtn,
+} from '@/libs/shared/click-btns/feature/click-btns'
 import { options } from '@/libs/shared/input-select-btn/data-access/mock-data'
 import ImageInput from '@/libs/shared/input-select-btn/feature/feature-image-input'
 import Input from '@/libs/shared/input-select-btn/feature/feature-input'
@@ -11,32 +19,134 @@ import styles from './feature-register-shop-modal-default-content.module.scss'
 const cx = classNames.bind(styles)
 
 export default function RegisterShopModalDefaultContent() {
+  const [shopName, setShopName] = useState<string>('')
+  const [category, setCategory] = useState<string>('')
+  const [address, setAddress] = useState<string>('')
+  const [detailAddress, setDetailAddress] = useState<string>('')
+  const [defaultHourlyWage, setDefaultHourlyWage] = useState<number>()
+  // const [shopImage, setShopImage] = useState<string>('')
+  const [description, setDescription] = useState<string>('')
+  const [isAllFilled, setIsAllFilled] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (
+      shopName &&
+      category &&
+      address &&
+      detailAddress &&
+      defaultHourlyWage &&
+      description
+    ) {
+      setIsAllFilled(true)
+      return
+    }
+    setIsAllFilled(false)
+  }, [
+    address,
+    category,
+    defaultHourlyWage,
+    description,
+    detailAddress,
+    shopName,
+  ])
+
+  const handleChangeShopName = (e: ChangeEvent<HTMLInputElement>) => {
+    console.log('setShopName')
+    setShopName(e.target.value)
+  }
+
+  const handleClickCategory = (value: string) => {
+    setCategory(value)
+    console.log('category')
+  }
+  const handleChangeAddress = (e: ChangeEvent<HTMLInputElement>) => {
+    console.log('setAddress')
+
+    setAddress(e.target.value)
+  }
+
+  const handleChangeDetailAddress = (e: ChangeEvent<HTMLInputElement>) => {
+    console.log('setDetailAddress')
+    setDetailAddress(e.target.value)
+  }
+
+  const handleChangeDefaultHourlyWage = (e: ChangeEvent<HTMLInputElement>) => {
+    console.log('setDefaultHourlyWage')
+    setDefaultHourlyWage(Number(e.target.value))
+  }
+
+  const handleChangeDescription = (e: ChangeEvent<HTMLInputElement>) => {
+    console.log('setDescription')
+    setDescription(e.target.value)
+  }
+
   return (
     <UiSimpleLayout title="가게 정보">
       <div className={cx('contentWrap')}>
         <div className={cx('inputContainer')}>
-          <Input variant="input" title="가게 이름*" isRequired={true} />
+          <Input
+            variant="input"
+            title="가게 이름*"
+            isRequired={true}
+            onChange={handleChangeShopName}
+          />
           <Select
             title="분류*"
             variant="search"
             options={options}
             defaultValue={options[0].value}
+            onClick={handleClickCategory}
           />
         </div>
         <div className={cx('inputContainer')}>
-          <Input variant="input" title="주소*" isRequired={true} />
+          <Input
+            variant="input"
+            title="주소*"
+            isRequired={true}
+            onChange={handleChangeAddress}
+          />
 
-          <Input variant="input" title="상세 주소*" isRequired={true} />
+          <Input
+            variant="input"
+            title="상세 주소*"
+            isRequired={true}
+            onChange={handleChangeDetailAddress}
+          />
         </div>
         <div className={cx('inputContainer')}>
-          <Input variant="input" title="기본 시급*" isRequired={true} />
+          <Input
+            variant="input"
+            title="기본 시급*"
+            isRequired={true}
+            onChange={handleChangeDefaultHourlyWage}
+          />
         </div>
         <div className={cx('inputContainer')}>
           <ImageInput title="가게 이미지" preselectedImageUrl="" />
         </div>
         <div className={cx('textAreaContainer')}>
-          <Input variant="explain" title="가게 설명*" isRequired={true} />
+          <Input
+            variant="explain"
+            title="가게 설명*"
+            isRequired={true}
+            onChange={handleChangeDescription}
+          />
         </div>
+      </div>
+      <div className={cx('button')}>
+        {isAllFilled ? (
+          <ActiveBtn
+            text="완료하기"
+            size="large"
+            onClick={() => console.log('모달 닫기')}
+          />
+        ) : (
+          <InactiveBtn
+            text="완료하기"
+            size="large"
+            onClick={() => console.log('아직 안채워짐')}
+          />
+        )}
       </div>
     </UiSimpleLayout>
   )

--- a/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
+++ b/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import classNames from 'classnames/bind'
 
@@ -23,10 +23,13 @@ export default function RegisterShopModalDefaultContent() {
   const [category, setCategory] = useState<string>('')
   const [address, setAddress] = useState<string>('')
   const [detailAddress, setDetailAddress] = useState<string>('')
+
   const [defaultHourlyWage, setDefaultHourlyWage] = useState<
     number | undefined
   >(undefined)
-  // const [shopImage, setShopImage] = useState<string>('')
+  const [selectedImage, setSelectedImage] = useState<string>('')
+  const preselectedImageRef = useRef<HTMLImageElement>(null)
+
   const [description, setDescription] = useState<string>('')
   const [isAllFilled, setIsAllFilled] = useState<boolean>(false)
 
@@ -36,6 +39,7 @@ export default function RegisterShopModalDefaultContent() {
       category &&
       address &&
       detailAddress &&
+      (selectedImage || preselectedImageRef.current) &&
       defaultHourlyWage &&
       description
     ) {
@@ -43,14 +47,7 @@ export default function RegisterShopModalDefaultContent() {
     } else {
       setIsAllFilled(false)
     }
-    console.log(
-      address,
-      category,
-      defaultHourlyWage,
-      description,
-      detailAddress,
-      shopName,
-    )
+    console.log(selectedImage, preselectedImageRef.current)
   }, [
     address,
     category,
@@ -58,6 +55,8 @@ export default function RegisterShopModalDefaultContent() {
     description,
     detailAddress,
     shopName,
+    preselectedImageRef,
+    selectedImage,
   ])
 
   return (
@@ -102,7 +101,13 @@ export default function RegisterShopModalDefaultContent() {
           />
         </div>
         <div className={cx('inputContainer')}>
-          <ImageInput title="가게 이미지" preselectedImageUrl="" />
+          <ImageInput
+            title="가게 이미지"
+            preselectedImageUrl=""
+            selectedImage={selectedImage}
+            setSelectedImage={setSelectedImage}
+            ref={preselectedImageRef}
+          />
         </div>
         <div className={cx('textAreaContainer')}>
           <Input

--- a/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
+++ b/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChangeEvent, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import classNames from 'classnames/bind'
 
@@ -23,7 +23,9 @@ export default function RegisterShopModalDefaultContent() {
   const [category, setCategory] = useState<string>('')
   const [address, setAddress] = useState<string>('')
   const [detailAddress, setDetailAddress] = useState<string>('')
-  const [defaultHourlyWage, setDefaultHourlyWage] = useState<number>()
+  const [defaultHourlyWage, setDefaultHourlyWage] = useState<
+    number | undefined
+  >(undefined)
   // const [shopImage, setShopImage] = useState<string>('')
   const [description, setDescription] = useState<string>('')
   const [isAllFilled, setIsAllFilled] = useState<boolean>(false)
@@ -38,9 +40,17 @@ export default function RegisterShopModalDefaultContent() {
       description
     ) {
       setIsAllFilled(true)
-      return
+    } else {
+      setIsAllFilled(false)
     }
-    setIsAllFilled(false)
+    console.log(
+      address,
+      category,
+      defaultHourlyWage,
+      description,
+      detailAddress,
+      shopName,
+    )
   }, [
     address,
     category,
@@ -50,36 +60,6 @@ export default function RegisterShopModalDefaultContent() {
     shopName,
   ])
 
-  const handleChangeShopName = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log('setShopName')
-    setShopName(e.target.value)
-  }
-
-  const handleClickCategory = (value: string) => {
-    setCategory(value)
-    console.log('category')
-  }
-  const handleChangeAddress = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log('setAddress')
-
-    setAddress(e.target.value)
-  }
-
-  const handleChangeDetailAddress = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log('setDetailAddress')
-    setDetailAddress(e.target.value)
-  }
-
-  const handleChangeDefaultHourlyWage = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log('setDefaultHourlyWage')
-    setDefaultHourlyWage(Number(e.target.value))
-  }
-
-  const handleChangeDescription = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log('setDescription')
-    setDescription(e.target.value)
-  }
-
   return (
     <UiSimpleLayout title="가게 정보">
       <div className={cx('contentWrap')}>
@@ -88,14 +68,14 @@ export default function RegisterShopModalDefaultContent() {
             variant="input"
             title="가게 이름*"
             isRequired={true}
-            onChange={handleChangeShopName}
+            onChange={(e) => setShopName(e.target.value)}
           />
           <Select
             title="분류*"
             variant="search"
             options={options}
             defaultValue={options[0].value}
-            onClick={handleClickCategory}
+            onClick={(value) => setCategory(value)}
           />
         </div>
         <div className={cx('inputContainer')}>
@@ -103,14 +83,14 @@ export default function RegisterShopModalDefaultContent() {
             variant="input"
             title="주소*"
             isRequired={true}
-            onChange={handleChangeAddress}
+            onChange={(e) => setAddress(e.target.value)}
           />
 
           <Input
             variant="input"
             title="상세 주소*"
             isRequired={true}
-            onChange={handleChangeDetailAddress}
+            onChange={(e) => setDetailAddress(e.target.value)}
           />
         </div>
         <div className={cx('inputContainer')}>
@@ -118,7 +98,7 @@ export default function RegisterShopModalDefaultContent() {
             variant="input"
             title="기본 시급*"
             isRequired={true}
-            onChange={handleChangeDefaultHourlyWage}
+            onChange={(e) => setDefaultHourlyWage(Number(e.target.value))}
           />
         </div>
         <div className={cx('inputContainer')}>
@@ -129,7 +109,7 @@ export default function RegisterShopModalDefaultContent() {
             variant="explain"
             title="가게 설명*"
             isRequired={true}
-            onChange={handleChangeDescription}
+            onChange={(e) => setDescription(e.target.value)}
           />
         </div>
       </div>

--- a/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
+++ b/libs/my-shop-eva/feature/feature-register-shop-modal-default-contnet.tsx
@@ -1,0 +1,43 @@
+import classNames from 'classnames/bind'
+
+import { options } from '@/libs/shared/input-select-btn/data-access/mock-data'
+import ImageInput from '@/libs/shared/input-select-btn/feature/feature-image-input'
+import Input from '@/libs/shared/input-select-btn/feature/feature-input'
+import Select from '@/libs/shared/input-select-btn/feature/feature-select'
+import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
+
+import styles from './feature-register-shop-modal-default-content.module.scss'
+
+const cx = classNames.bind(styles)
+
+export default function RegisterShopModalDefaultContent() {
+  return (
+    <UiSimpleLayout title="가게 정보">
+      <div className={cx('contentWrap')}>
+        <div className={cx('inputContainer')}>
+          <Input variant="input" title="가게 이름*" isRequired={true} />
+          <Select
+            title="분류*"
+            variant="search"
+            options={options}
+            defaultValue={options[0].value}
+          />
+        </div>
+        <div className={cx('inputContainer')}>
+          <Input variant="input" title="주소*" isRequired={true} />
+
+          <Input variant="input" title="상세 주소*" isRequired={true} />
+        </div>
+        <div className={cx('inputContainer')}>
+          <Input variant="input" title="기본 시급*" isRequired={true} />
+        </div>
+        <div className={cx('inputContainer')}>
+          <ImageInput title="가게 이미지" preselectedImageUrl="" />
+        </div>
+        <div className={cx('textAreaContainer')}>
+          <Input variant="explain" title="가게 설명*" isRequired={true} />
+        </div>
+      </div>
+    </UiSimpleLayout>
+  )
+}

--- a/libs/my-shop-eva/feature/feature-register-shop-modal.tsx
+++ b/libs/my-shop-eva/feature/feature-register-shop-modal.tsx
@@ -1,0 +1,16 @@
+import UiBgGrayModal from '@/libs/shared/bg-gray-modal/ui/ui-bg-gray-modal/ui-bg-gray-modal'
+
+import RegisterShopModalDefaultContent from './feature-register-shop-modal-default-contnet'
+
+/**
+ * @param onCloseModal X 버튼으로 모달 끄는 setter
+ * @param children content 내용물
+ * @returns 회색 배경과 X 버튼이 담긴 full screen 모달
+ */
+export default function RegisterShopModal() {
+  return (
+    <UiBgGrayModal>
+      <RegisterShopModalDefaultContent />
+    </UiBgGrayModal>
+  )
+}

--- a/libs/shared/input-select-btn/feature/feature-image-input.tsx
+++ b/libs/shared/input-select-btn/feature/feature-image-input.tsx
@@ -1,18 +1,24 @@
 'use client'
 
-import React, { useRef, useState } from 'react'
+import { ForwardedRef, forwardRef, useRef } from 'react'
 
 import UiAddImageBtn from '@/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn'
 import UiImageInput from '@/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input'
 
-export default function ImageInput({
-  title,
-  preselectedImageUrl = undefined,
-}: {
-  title: string
-  preselectedImageUrl?: string
-}) {
-  const [selectedImage, setSelectedImage] = useState<string>('')
+export default forwardRef(function ImageInput(
+  {
+    title,
+    preselectedImageUrl = undefined,
+    selectedImage,
+    setSelectedImage,
+  }: {
+    title: string
+    preselectedImageUrl?: string
+    selectedImage: string
+    setSelectedImage: (selectedImage: string) => void
+  },
+  ref: ForwardedRef<HTMLImageElement>,
+) {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const handleImage = (file: File) => {
@@ -65,7 +71,8 @@ export default function ImageInput({
       <UiAddImageBtn
         onClickAddImageButton={handleClickButton}
         preselectedImageUrl={preselectedImageUrl}
+        ref={ref}
       />
     </UiImageInput>
   )
-}
+})

--- a/libs/shared/input-select-btn/feature/feature-input.tsx
+++ b/libs/shared/input-select-btn/feature/feature-input.tsx
@@ -5,15 +5,26 @@ import UiTextArea from '@/libs/shared/input-select-btn/ui/ui-text-area/ui-text-a
 
 import { FeatureInputProps } from '../types/type-input'
 
+/**
+ * @param variant ("input"| "input-underline"|"explain")
+ * @param title (string)
+ * @param isRequired (boolean)
+ * @param ref input 태그에 붙는 ref
+ * @param onChange input value가 변경되면 실행할 함수(option)
+ * @param defaultValue (string(option))
+ * @param valid (string(option))
+ * @param isValid (boolean(option))
+ * @param suffix (string(option))
+ */
 export default forwardRef(function Input(
   {
     onChange,
     variant = 'input',
     title,
+    isRequired,
     defaultValue,
     valid,
     isValid,
-    isRequired,
     suffix,
   }: FeatureInputProps,
   ref: ForwardedRef<HTMLInputElement | HTMLTextAreaElement>,

--- a/libs/shared/input-select-btn/feature/feature-input.tsx
+++ b/libs/shared/input-select-btn/feature/feature-input.tsx
@@ -29,7 +29,7 @@ export default forwardRef(function Input(
   }: FeatureInputProps,
   ref: ForwardedRef<HTMLInputElement | HTMLTextAreaElement>,
 ) {
-  if (variant === 'input') {
+  if (variant === 'input' || variant === 'input-underline') {
     return (
       <UiInput
         variant={variant}
@@ -44,10 +44,10 @@ export default forwardRef(function Input(
       />
     )
   }
-
-  if (variant === 'explain') {
+  if (variant === 'explain' || variant === 'explain-underline') {
     return (
       <UiTextArea
+        variant={variant}
         title={title}
         defaultValue={defaultValue}
         valid={valid as string}
@@ -55,22 +55,6 @@ export default forwardRef(function Input(
         isRequired={isRequired}
         onChange={onChange as (e: ChangeEvent<HTMLTextAreaElement>) => void}
         ref={ref as ForwardedRef<HTMLTextAreaElement>}
-      />
-    )
-  }
-
-  if (variant === 'input-underline') {
-    return (
-      <UiInput
-        variant={variant}
-        onChange={onChange as (e: ChangeEvent<HTMLInputElement>) => void}
-        title={title}
-        defaultValue={defaultValue}
-        valid={valid as string}
-        isValid={isValid as boolean}
-        isRequired={isRequired}
-        suffix={suffix}
-        ref={ref as ForwardedRef<HTMLInputElement>}
       />
     )
   }

--- a/libs/shared/input-select-btn/feature/feature-input.tsx
+++ b/libs/shared/input-select-btn/feature/feature-input.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import React, { ChangeEvent, ForwardedRef, forwardRef } from 'react'
 
 import UiInput from '@/libs/shared/input-select-btn/ui/ui-input/ui-input'
 import UiTextArea from '@/libs/shared/input-select-btn/ui/ui-text-area/ui-text-area'
@@ -33,7 +33,7 @@ export default forwardRef(function Input(
     return (
       <UiInput
         variant={variant}
-        onChange={onChange}
+        onChange={onChange as (e: ChangeEvent<HTMLInputElement>) => void}
         title={title}
         defaultValue={defaultValue}
         valid={valid as string}
@@ -53,6 +53,7 @@ export default forwardRef(function Input(
         valid={valid as string}
         isValid={isValid as boolean}
         isRequired={isRequired}
+        onChange={onChange as (e: ChangeEvent<HTMLTextAreaElement>) => void}
         ref={ref as ForwardedRef<HTMLTextAreaElement>}
       />
     )
@@ -62,7 +63,7 @@ export default forwardRef(function Input(
     return (
       <UiInput
         variant={variant}
-        onChange={onChange}
+        onChange={onChange as (e: ChangeEvent<HTMLInputElement>) => void}
         title={title}
         defaultValue={defaultValue}
         valid={valid as string}

--- a/libs/shared/input-select-btn/feature/feature-select.tsx
+++ b/libs/shared/input-select-btn/feature/feature-select.tsx
@@ -8,6 +8,14 @@ import useSelect from '@/libs/shared/input-select-btn/util/useSelect'
 import { SelectProps } from '../types/type-select'
 import UiSelectTopShell from '../ui/ui-select/ui-select-top-shell'
 
+/**
+ * @params   variant: 'search' | 'filter'
+ * @params  title?: string
+ * @params  isRequired?: boolean
+ * @params  options: Option[]
+ * @params  defaultValue: string
+ * @params  onClick?: (value: string) => void
+ */
 export default forwardRef(function Select(
   props: SelectProps,
   ref: ForwardedRef<HTMLInputElement>,

--- a/libs/shared/input-select-btn/types/type-input.ts
+++ b/libs/shared/input-select-btn/types/type-input.ts
@@ -26,7 +26,7 @@ export interface UiImageInputProps {
 }
 
 export type Variant = {
-  variant: 'input' | 'explain' | 'input-underline'
+  variant: 'input' | 'explain' | 'input-underline' | 'explain-underline'
 }
 export type FeatureInputProps = Variant &
   InputProps &

--- a/libs/shared/input-select-btn/types/type-input.ts
+++ b/libs/shared/input-select-btn/types/type-input.ts
@@ -6,7 +6,9 @@ export interface InputProps {
   defaultValue?: string
   isRequired: boolean
   suffix?: string
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChange?: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
 }
 
 export interface Valid {

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.module.scss
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.module.scss
@@ -9,6 +9,14 @@
   border: 1px solid utils.$gray-brt3;
   border-radius: 12px;
   background-color: utils.$gray-brt5;
+
+  @include utils.tablet {
+    width: 100%;
+  }
+
+  @include utils.mobile {
+    height: 50vh;
+  }
 }
 
 .preSelectedImage {

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.tsx
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-add-image-btn.tsx
@@ -1,3 +1,5 @@
+import { ForwardedRef, forwardRef } from 'react'
+
 import classNames from 'classnames/bind'
 
 import Image from 'next/image'
@@ -6,13 +8,16 @@ import styles from './ui-add-image-btn.module.scss'
 
 const cx = classNames.bind(styles)
 
-export default function UiAddImageBtn({
-  onClickAddImageButton,
-  preselectedImageUrl,
-}: {
-  onClickAddImageButton: () => void
-  preselectedImageUrl?: string
-}) {
+export default forwardRef(function UiAddImageBtn(
+  {
+    onClickAddImageButton,
+    preselectedImageUrl,
+  }: {
+    onClickAddImageButton: () => void
+    preselectedImageUrl?: string
+  },
+  ref: ForwardedRef<HTMLImageElement>,
+) {
   const buttonType = preselectedImageUrl ? '변경' : '추가'
   return (
     <button
@@ -21,10 +26,12 @@ export default function UiAddImageBtn({
       className={cx('addButton')}
     >
       {preselectedImageUrl && (
+        // eslint-disable-next-line @next/next/no-img-element
         <img
           alt="예전에 선택한 이미지"
           className={cx('preSelectedImage')}
           src={preselectedImageUrl}
+          ref={ref}
         />
       )}
       <div className={cx('buttonContent')}>
@@ -41,4 +48,4 @@ export default function UiAddImageBtn({
       </div>
     </button>
   )
-}
+})

--- a/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.module.scss
+++ b/libs/shared/input-select-btn/ui/ui-image-input/ui-image-input.module.scss
@@ -16,6 +16,14 @@
   width: 483px;
   height: 276px;
   border-radius: 12px;
+
+  @include utils.tablet {
+    width: 100%;
+  }
+
+  @include utils.mobile {
+    height: 50vh;
+  }
 }
 
 .buttonContent {

--- a/libs/shared/input-select-btn/ui/ui-input/ui-input.tsx
+++ b/libs/shared/input-select-btn/ui/ui-input/ui-input.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import React, { ChangeEvent, ForwardedRef, forwardRef } from 'react'
 
 import classNames from 'classnames/bind'
 
@@ -20,7 +20,10 @@ export default forwardRef(function UiInput(
     isValid,
     suffix,
     onChange,
-  }: Valid & InputProps,
+  }: Valid &
+    Omit<InputProps, 'onChange'> & {
+      onChange: (e: ChangeEvent<HTMLInputElement>) => void
+    },
   ref: ForwardedRef<HTMLInputElement>,
 ) {
   return (

--- a/libs/shared/input-select-btn/ui/ui-select/ui-select.module.scss
+++ b/libs/shared/input-select-btn/ui/ui-select/ui-select.module.scss
@@ -1,6 +1,7 @@
 @use '@/styles/utils';
 
 .selectWrap {
+  z-index: 10;
   width: 100%;
 }
 

--- a/libs/shared/input-select-btn/ui/ui-text-area/ui-text-area.module.scss
+++ b/libs/shared/input-select-btn/ui/ui-text-area/ui-text-area.module.scss
@@ -26,6 +26,13 @@
   &::placeholder {
     color: utils.$gray-brt2; /* 색상 설정 */
   }
+
+  &.underline {
+    height: 50vh;
+    padding: 16px 0;
+    border: none;
+    border-bottom: 1px solid utils.$gray-brt4;
+  }
 }
 
 .validText {

--- a/libs/shared/input-select-btn/ui/ui-text-area/ui-text-area.tsx
+++ b/libs/shared/input-select-btn/ui/ui-text-area/ui-text-area.tsx
@@ -13,6 +13,7 @@ const cx = classNames.bind(styles)
 
 export default forwardRef(function UiTextArea(
   {
+    variant,
     title,
     defaultValue,
     valid,
@@ -20,17 +21,19 @@ export default forwardRef(function UiTextArea(
     isRequired,
     onChange,
   }: Valid &
-    Omit<InputProps, 'variant' | 'onChange'> & {
+    Omit<InputProps, 'onChange'> & {
       onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
     },
   ref: ForwardedRef<HTMLTextAreaElement>,
 ) {
   return (
     <div className={cx('wrap')}>
-      <div className={cx('title')}>{title}</div>
+      {variant === 'explain' && <div className={cx('title')}>{title}</div>}
       <textarea
-        className={cx('textArea')}
-        placeholder="입력"
+        className={cx('textArea', {
+          underline: variant === 'explain-underline',
+        })}
+        placeholder={variant === 'explain' ? '입력' : title}
         required={isRequired}
         ref={ref}
         defaultValue={defaultValue}

--- a/libs/shared/input-select-btn/ui/ui-text-area/ui-text-area.tsx
+++ b/libs/shared/input-select-btn/ui/ui-text-area/ui-text-area.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react'
+import React, { ChangeEvent, ForwardedRef, forwardRef } from 'react'
 
 import classNames from 'classnames/bind'
 
@@ -18,7 +18,11 @@ export default forwardRef(function UiTextArea(
     valid,
     isValid,
     isRequired,
-  }: Valid & Omit<InputProps, 'variant'>,
+    onChange,
+  }: Valid &
+    Omit<InputProps, 'variant' | 'onChange'> & {
+      onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
+    },
   ref: ForwardedRef<HTMLTextAreaElement>,
 ) {
   return (
@@ -30,6 +34,7 @@ export default forwardRef(function UiTextArea(
         required={isRequired}
         ref={ref}
         defaultValue={defaultValue}
+        onChange={onChange as (e: ChangeEvent<HTMLTextAreaElement>) => void}
       />
       {isValid && <div className={cx('validText')}>{valid}</div>}
     </div>

--- a/libs/signup/ui/ui-signup/ui-signup.tsx
+++ b/libs/signup/ui/ui-signup/ui-signup.tsx
@@ -43,9 +43,9 @@ export default function UiSignUp({
       >
         <form className={cx('form')}>
           <Input
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              utilCheck('email', e.currentTarget.value)
-            }
+            onChange={(
+              e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+            ) => utilCheck('email', e.currentTarget.value)}
             variant="input"
             title="이메일"
             valid="잘못된 이메일입니다."
@@ -55,9 +55,9 @@ export default function UiSignUp({
             ref={(el: HTMLInputElement) => (userInputRefs.current[0] = el)}
           />
           <Input
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              utilCheck('pw', e.currentTarget.value)
-            }
+            onChange={(
+              e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+            ) => utilCheck('pw', e.currentTarget.value)}
             variant="input"
             title="비밀번호"
             valid="비밀번호는 영문+숫자 조합해서 8자리 이상이어야 합니다."
@@ -67,9 +67,9 @@ export default function UiSignUp({
             ref={(el: HTMLInputElement) => (userInputRefs.current[1] = el)}
           />
           <Input
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              utilCheck('pwRepeat', e.currentTarget.value)
-            }
+            onChange={(
+              e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+            ) => utilCheck('pwRepeat', e.currentTarget.value)}
             variant="input"
             title="비밀번호 확인"
             valid="비밀번호가 일치하지 않습니다."


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정

## 설명
- `RegisterShopModal` (PC버전) 구현
   - validation까지가
-이미지 선택 validate를 위한 `ImageInput` ref 및 state props 추가
- text area funnel을 위한 underline style 추가

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #80 


### Key Changes

- 설명과 동일


### How it Works

- 각 input의 value를 state로 하고, state 값이 falsy값이면 inactive 버튼, 다채워지면 active 버튼이 렌더링 되는 모달


### To Reviewers

