### PR TITLE
✅ 검색 공고 목록 컴포넌트 구현

### DIFF
--- a/libs/notice-list/feature/notice-list.tsx
+++ b/libs/notice-list/feature/notice-list.tsx
@@ -8,8 +8,6 @@ import UiFilterElement from '@/libs/shared/notice-card/ui/ui-filter-element/ui-f
 
 import UiNoticeList from '../ui/ui-notice-list/ui-notice-list'
 
-export type SortType = '마감임박순' | '시급많은순' | '시간적은순' | '가나다순'
-
 export default function NoticeList({
   keyword,
 }: {

--- a/libs/notice-list/feature/notice-list.tsx
+++ b/libs/notice-list/feature/notice-list.tsx
@@ -10,7 +10,11 @@ import UiNoticeList from '../ui/ui-notice-list/ui-notice-list'
 
 export type SortType = '마감임박순' | '시급많은순' | '시간적은순' | '가나다순'
 
-export default function NoticeList() {
+export default function NoticeList({
+  keyword,
+}: {
+  keyword: string | undefined
+}) {
   const [data, setData] = useState<AllNoticesData[]>([])
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
 
@@ -40,7 +44,7 @@ export default function NoticeList() {
         break
     }
 
-    const response = await getNotices({ limit: 6, sort: sortStr })
+    const response = await getNotices({ limit: 6, sort: sortStr, keyword })
     if (response instanceof Error) {
       // 알 수 없는 에러 처리
     } else if (typeof response === 'string') {
@@ -63,6 +67,7 @@ export default function NoticeList() {
       address: selectedLocations,
       startsAtGte: start,
       hourlyPayGte: price,
+      keyword,
     })
     if (response instanceof Error) {
       // 알 수 없는 에러 처리
@@ -78,7 +83,7 @@ export default function NoticeList() {
 
   useEffect(() => {
     const getDatas = async () => {
-      const response = await getNotices({ limit: 6 })
+      const response = await getNotices({ limit: 6, keyword })
       if (response instanceof Error) {
         // 알 수 없는 에러 처리
       } else if (typeof response === 'string') {
@@ -92,7 +97,7 @@ export default function NoticeList() {
     }
     getDatas()
     return undefined
-  }, [])
+  }, [keyword])
   return (
     <UiNoticeList
       data={data}

--- a/libs/search-notice-list/feature/search-notice-list.tsx
+++ b/libs/search-notice-list/feature/search-notice-list.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import NoticeList from '@/libs/notice-list/feature/notice-list'
+
+export default function SearchNoticeList({
+  searchParams,
+}: {
+  searchParams: { keyword: string }
+}) {
+  const { keyword } = searchParams
+
+  return (
+    <div>
+      <NoticeList keyword={keyword} />
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정

## 설명
검색 공고 목록 컴포넌트입니다


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #107 


### Key Changes

- 불필요한 타입 정의를 삭제했습니다.
- NoticeList 컴포넌트에서 keyword prop을 받아 있을 경우 API에 붙여 데이터를 요청합니다.

### How it Works

- gnb에 검색어를 입력하면 쿼리로 keyword를 붙여서(e.g. /search?keyword=something) 페이지 라우팅
- 검색 공고 목록 컴포넌트에서 keyword 쿼리 값을 가져와 API 호출
- 받아온 데이터로 렌더링


### To Reviewers

- 로직이 생각보다 간단한거였는데 어렵게 생각하다보니 시간이 좀 걸렸습니다 ㅠㅠ
