### PR TITLE
공고 상세 페이지 라우팅 및 맞춤 공고 데이터 불러오기 구현

### DIFF
--- a/libs/custom-notice-list/data-access/get-all-notices.ts
+++ b/libs/custom-notice-list/data-access/get-all-notices.ts
@@ -1,0 +1,13 @@
+import { getNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
+
+export const getAllNotices = async () => {
+  const response = await getNotices({})
+  if (response instanceof Error) {
+    return []
+  }
+  if (typeof response === 'string') {
+    return []
+  }
+  const { items } = response
+  return items
+}

--- a/libs/custom-notice-list/data-access/get-custom-datas.ts
+++ b/libs/custom-notice-list/data-access/get-custom-datas.ts
@@ -1,0 +1,73 @@
+import { getNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
+import { getUserInfo } from '@/libs/shared/api/data-access/request/userRequest'
+import { utilFormatDuration } from '@/libs/shared/shared/util/utilFormatDuration'
+
+import { getAllNotices } from './get-all-notices'
+
+const getUserAddress = async (userid: string) => {
+  const res = await getUserInfo(userid)
+  if (res instanceof Error) {
+    return ''
+  }
+  if (typeof res === 'string') {
+    return ''
+  }
+  const { item } = res
+  const { type } = item
+
+  if (type === 'employee' && item.address) {
+    const { address } = item
+    return address
+  }
+  if (type === 'employer' && item.shop) {
+    const { address1 } = item.shop.item
+    return address1
+  }
+  return ''
+}
+
+const getCustomDatas = async (
+  userId: string,
+  handleClickToDetail: (
+    isClosed: boolean,
+    shopId: string,
+    noticeId: string,
+  ) => void,
+) => {
+  const addressArr: string[] = []
+  if (userId) {
+    const address = await getUserAddress(userId)
+    addressArr.push(address)
+  }
+  const response = await getNotices({ address: addressArr })
+  if (response instanceof Error) {
+    return []
+  }
+  if (typeof response === 'string') {
+    return []
+  }
+  let { items } = response
+  if (items.length === 0) {
+    items = await getAllNotices()
+  }
+  const itemsArray = items.map((item) => item.item)
+  const itemDatas = itemsArray.map((item) => ({
+    name: item.shop.item.name,
+    id: item.id,
+    duration: utilFormatDuration(item.startsAt, item.workhour),
+    workhour: item.workhour,
+    address: item.shop.item.address1,
+    hourlyPay: item.hourlyPay,
+    originalHourlyPay: item.shop.item.originalHourlyPay,
+    imageUrl: item.shop.item.imageUrl,
+    closed: item.closed,
+    shopId: item.shop.item.id,
+    handleClickToDetail: () =>
+      handleClickToDetail(item.closed, item.shop.item.id, item.id),
+  }))
+
+  const filteredItemDatas = itemDatas.filter((item) => !item.closed)
+  return filteredItemDatas
+}
+
+export default getCustomDatas

--- a/libs/custom-notice-list/feature/custom-notice-list.tsx
+++ b/libs/custom-notice-list/feature/custom-notice-list.tsx
@@ -19,7 +19,7 @@ import styles from './custom-notice-list.module.scss'
 
 const cx = classNames.bind(styles)
 
-export default function UiCustomNoticeList() {
+export default function CustomNoticeList() {
   const router = useRouter()
   const sliderRef = useRef<HTMLDivElement>(null)
   const [customDatas, setCustomDatas] = useState<NoticeCardItemProps[]>([])
@@ -77,7 +77,7 @@ export default function UiCustomNoticeList() {
                 notice.hourlyPay,
                 notice.originalHourlyPay,
               )}
-              handleClickToDetail={() =>
+              onClickToDetail={() =>
                 handleClickToDetail(notice.closed, notice.shopId, notice.id)
               }
             />

--- a/libs/custom-notice-list/feature/custom-notice-list.tsx
+++ b/libs/custom-notice-list/feature/custom-notice-list.tsx
@@ -3,15 +3,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import classNames from 'classnames/bind'
+import { getCookie } from 'cookies-next'
 
 import { useRouter } from 'next/navigation'
 
+import getCustomDatas from '@/libs/custom-notice-list/data-access/get-custom-datas'
 import { NoticeCardItemProps } from '@/libs/custom-notice-list/type-custom-notice-list'
-import { getNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
+import utilAutoplaySlider from '@/libs/custom-notice-list/utils/util-autoplay'
 import UiNoticeCardItem from '@/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item'
 import { utilCalcChangeRate } from '@/libs/shared/notice-card/util/util-calc-change-rate'
 import { utilCalcPayDiff } from '@/libs/shared/notice-card/util/util-calc-pay-diff'
-import { utilFormatDuration } from '@/libs/shared/notice-card/util/util-format-duration'
 import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
 import styles from './custom-notice-list.module.scss'
@@ -20,31 +21,11 @@ const cx = classNames.bind(styles)
 
 export default function UiCustomNoticeList() {
   const router = useRouter()
-  const sliderRef = useRef<HTMLDivElement | null>(null)
-  const [datas, setDatas] = useState<NoticeCardItemProps[]>([])
+  const sliderRef = useRef<HTMLDivElement>(null)
+  const [customDatas, setCustomDatas] = useState<NoticeCardItemProps[]>([])
 
   const handleAutoplaySlider = useCallback(() => {
-    if (sliderRef.current) {
-      const sliderWrapper = sliderRef.current
-      const { scrollLeft } = sliderWrapper
-
-      const totalWidth = sliderWrapper.scrollWidth
-      const firstCardWidth =
-        sliderWrapper.children[0]?.getBoundingClientRect().width
-      const cardWidth =
-        window.innerWidth > 768 ? firstCardWidth + 14 : firstCardWidth + 4
-
-      let nextScrollLeft = scrollLeft + cardWidth
-
-      if (nextScrollLeft > totalWidth - cardWidth * 2) {
-        nextScrollLeft = 0
-      }
-
-      sliderWrapper.scrollTo({
-        left: nextScrollLeft,
-        behavior: 'smooth',
-      })
-    }
+    utilAutoplaySlider(sliderRef)
   }, [])
 
   useEffect(() => {
@@ -56,54 +37,35 @@ export default function UiCustomNoticeList() {
   }, [handleAutoplaySlider])
 
   const handleClickToDetail = useCallback(
-    (isClosed: boolean) => {
+    (isClosed: boolean, shopId: string, noticeId: string) => {
       if (isClosed) return
-      router.push('/')
+      const userShopId = getCookie('shop_id') as string
+
+      if (userShopId === shopId) {
+        router.push(`/myshop/${noticeId}`)
+      } else {
+        router.push(`/${shopId}/${noticeId}`)
+      }
     },
     [router],
   )
 
   useEffect(() => {
-    // 1. 로그인 여부를 확인하고
-    // 2. 로그인이 되어 있다면 유저 타입을 확인하여
-    // 2-1. 사장이면 본인 가게 address 기준으로 데이터 뽑아오고
-    // 2-2. 알바면 유저 정보에 있는 선호지역 기준으로 데이터 뽑아오는 로직이 추가되어야 함
-    // 3-1. 로그인이 되어 있지 않으면 전체 데이터를 가져와서 렌더링
-    // 4. 일단은 전체 데이터를 뽑아오는 로직으로 대체
+    const userId = getCookie('uid') as string
 
-    const getData = async () => {
-      const response = await getNotices({})
-      if (response instanceof Error) {
-        // 알 수 없는 에러 처리
-      } else if (typeof response === 'string') {
-        // 에러 메시지에 맞게 처리
-      } else {
-        const { items } = response
-        const itemsArray = items.map((item) => item.item)
-        const itemDatas = itemsArray.map((item) => ({
-          name: item.shop.item.name,
-          id: item.id,
-          duration: utilFormatDuration(item.startsAt, item.workhour),
-          workhour: item.workhour,
-          address: item.shop.item.address1,
-          hourlyPay: item.hourlyPay,
-          originalHourlyPay: item.shop.item.originalHourlyPay,
-          imageUrl: item.shop.item.imageUrl,
-          closed: item.closed,
-          handleClickToDetail: () => handleClickToDetail(item.closed),
-        }))
-        setDatas(itemDatas)
-      }
+    const getDatas = async () => {
+      const datas = await getCustomDatas(userId, handleClickToDetail)
+      setCustomDatas(datas)
     }
-    getData()
-    return undefined
+
+    getDatas()
   }, [handleClickToDetail])
 
   return (
     <div className={cx('customListWrapper')}>
       <UiSimpleLayout title="맞춤 공고" gap={32}>
         <div className={cx('noticeCardWrapper')} ref={sliderRef}>
-          {datas.map((notice) => (
+          {customDatas.map((notice) => (
             <UiNoticeCardItem
               key={notice.id}
               {...notice}
@@ -115,7 +77,9 @@ export default function UiCustomNoticeList() {
                 notice.hourlyPay,
                 notice.originalHourlyPay,
               )}
-              handleClickToDetail={() => handleClickToDetail(notice.closed)}
+              handleClickToDetail={() =>
+                handleClickToDetail(notice.closed, notice.shopId, notice.id)
+              }
             />
           ))}
         </div>

--- a/libs/custom-notice-list/type-custom-notice-list.ts
+++ b/libs/custom-notice-list/type-custom-notice-list.ts
@@ -8,5 +8,6 @@ export interface NoticeCardItemProps {
   originalHourlyPay: number
   imageUrl: string
   closed: boolean
+  shopId: string
   handleClickToDetail: () => void
 }

--- a/libs/custom-notice-list/utils/util-autoplay.ts
+++ b/libs/custom-notice-list/utils/util-autoplay.ts
@@ -1,0 +1,25 @@
+const utilAutoplaySlider = (sliderRef: React.RefObject<HTMLDivElement>) => {
+  if (sliderRef.current) {
+    const sliderWrapper = sliderRef.current
+    const { scrollLeft } = sliderWrapper
+
+    const totalWidth = sliderWrapper.scrollWidth
+    const firstCardWidth =
+      sliderWrapper.children[0]?.getBoundingClientRect().width
+    const cardWidth =
+      window.innerWidth > 768 ? firstCardWidth + 14 : firstCardWidth + 4
+
+    let nextScrollLeft = scrollLeft + cardWidth
+
+    if (nextScrollLeft > totalWidth - cardWidth * 2) {
+      nextScrollLeft = 0
+    }
+
+    sliderWrapper.scrollTo({
+      left: nextScrollLeft,
+      behavior: 'smooth',
+    })
+  }
+}
+
+export default utilAutoplaySlider

--- a/libs/shared/detail-filter/ui/ui-detail-filter/ui-detail-filter.module.scss
+++ b/libs/shared/detail-filter/ui/ui-detail-filter/ui-detail-filter.module.scss
@@ -2,6 +2,7 @@
 
 .filterContainer {
   position: relative;
+  z-index: 100;
   width: 390px;
   padding: 24px 20px;
   overflow: auto;

--- a/libs/shared/notice-card/feature/notice-card-item.tsx
+++ b/libs/shared/notice-card/feature/notice-card-item.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { getCookie } from 'cookies-next'
+
 import { useRouter } from 'next/navigation'
 
 import { AllNoticesData } from '../../api/types/type-notice'
@@ -19,9 +21,19 @@ export default function NoticeCardItem({
 }) {
   const router = useRouter()
 
-  const handleClickToDetail = (isClosed: boolean) => {
+  const handleClickToDetail = (
+    isClosed: boolean,
+    shopId: string,
+    noticeId: string,
+  ) => {
     if (isClosed) return
-    router.push('/')
+    const userShopId = getCookie('shop_id') as string
+
+    if (userShopId === shopId) {
+      router.push(`/myshop/${noticeId}`)
+    } else {
+      router.push(`/${shopId}/${noticeId}`)
+    }
   }
 
   const itemDatas = data.map((item) => ({
@@ -34,7 +46,9 @@ export default function NoticeCardItem({
     originalHourlyPay: item.shop.item.originalHourlyPay,
     imageUrl: item.shop.item.imageUrl,
     closed: item.closed,
-    handleClickToDetail: () => handleClickToDetail(item.closed),
+    shopId: item.shop.item.id,
+    handleClickToDetail: () =>
+      handleClickToDetail(item.closed, item.shop.item.id, item.id),
   }))
 
   return (
@@ -57,7 +71,9 @@ export default function NoticeCardItem({
             notice.hourlyPay,
             notice.originalHourlyPay,
           )}
-          handleClickToDetail={() => handleClickToDetail(notice.closed)}
+          handleClickToDetail={() =>
+            handleClickToDetail(notice.closed, notice.shopId, notice.id)
+          }
         />
       ))}
     </UiNoticeCardList>

--- a/libs/shared/notice-card/feature/notice-card-item.tsx
+++ b/libs/shared/notice-card/feature/notice-card-item.tsx
@@ -71,7 +71,7 @@ export default function NoticeCardItem({
             notice.hourlyPay,
             notice.originalHourlyPay,
           )}
-          handleClickToDetail={() =>
+          onClickToDetail={() =>
             handleClickToDetail(notice.closed, notice.shopId, notice.id)
           }
         />

--- a/libs/shared/notice-card/feature/notice-card-item.tsx
+++ b/libs/shared/notice-card/feature/notice-card-item.tsx
@@ -30,7 +30,7 @@ export default function NoticeCardItem({
     const userShopId = getCookie('shop_id') as string
 
     if (userShopId === shopId) {
-      router.push(`/myshop/${noticeId}`)
+      router.push(`/my-shop/${noticeId}`)
     } else {
       router.push(`/${shopId}/${noticeId}`)
     }

--- a/libs/shared/notice-card/type-notice-card.ts
+++ b/libs/shared/notice-card/type-notice-card.ts
@@ -48,7 +48,7 @@ export interface UiNoticeCardItemProps {
   closed: boolean
   changeRate: undefined | number
   isShowChip: CardChips
-  handleClickToDetail: () => void
+  onClickToDetail: () => void
 }
 
 export interface UiNoticeCardListProps {

--- a/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.tsx
@@ -20,13 +20,13 @@ export default function UiNoticeCardItem({
   closed,
   changeRate,
   isShowChip,
-  handleClickToDetail,
+  onClickToDetail,
 }: UiNoticeCardItemProps) {
   return (
     <div
       role="presentation"
       className={cx('cardWrapper', { closed })}
-      onClick={handleClickToDetail}
+      onClick={onClickToDetail}
     >
       <div className={cx('imgContainer', 'header')}>
         <img className={cx('img')} src={imageUrl} alt={name} />

--- a/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.module.scss
+++ b/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.module.scss
@@ -19,8 +19,15 @@ $card-size-small: 171px;
 
   width: 100%;
 
+  @include utils.tablet {
+    padding: 0 32px;
+  }
+
   @include utils.mobile {
     @include utils.flexbox(column, flex-start, flex-start);
+
+    gap: 16px;
+    padding: 0 12px;
   }
 }
 
@@ -46,11 +53,12 @@ $card-size-small: 171px;
 .listWrapper {
   display: grid;
   grid-template-columns: repeat(3, $card-size-large);
-  margin: 0 auto;
   gap: 31px 14px;
 
   @include utils.tablet {
     grid-template-columns: repeat(2, $card-size-large);
+    margin: 0 auto;
+    padding: 0 32px;
   }
 
   @include utils.mobile {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- FIX : 버그 수정
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정


## 설명
공고 상세 페이지 라우팅 및 맞춤 공고 데이터 불러오기를 구현했습니다.


### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
closes #130, #140 


### Key Changes

- 함수 분리
- 로그인 여부 확인 로직 추가
- 유저 타입 확인 로직 추가
- shopId 및 noticeId를 이용하여 페이지 라우팅 기능 추가


### How it Works



### To Reviewers

