### PR TITLE
테이블 데이터 없을 때 UI 구현 및 일부 로직 수정

### DIFF
--- a/libs/my-shop-notice/feature/my-shop-notice-applicant.tsx
+++ b/libs/my-shop-notice/feature/my-shop-notice-applicant.tsx
@@ -26,6 +26,7 @@ export default async function MyShopNoticeApplicant({
         shopId={shopId}
         noticeId={noticeId}
         paginationElement={<Pagination page={page} totalItems={totalItems} />}
+        page={page}
       />
     </UiSimpleLayoutResponsive>
   )

--- a/libs/shared/pagination/feature/pagination.tsx
+++ b/libs/shared/pagination/feature/pagination.tsx
@@ -21,7 +21,7 @@ export default function Pagination({
   totalItems: number
 }) {
   const paginationNum = Math.floor((page - 1) / PAGES_PER_PAGINATION) + 1
-  const endPage = Math.floor((totalItems + 1) / TABLE_ITEMS_PER_PAGE)
+  const endPage = Math.floor((totalItems - 1) / TABLE_ITEMS_PER_PAGE) + 1
 
   const shownStart =
     Math.floor((page - 1) / PAGES_PER_PAGINATION) * PAGES_PER_PAGINATION + 1
@@ -30,6 +30,7 @@ export default function Pagination({
     { length: shownEnd - shownStart + 1 },
     (_, i) => i + shownStart,
   )
+
   return (
     <UiPagination
       page={page}

--- a/libs/shared/pagination/ui/ui-pagination.module.scss
+++ b/libs/shared/pagination/ui/ui-pagination.module.scss
@@ -43,9 +43,7 @@
   }
 }
 
-.arrow {
-  &.disabled {
-    cursor: default;
-    pointer-events: none;
-  }
+.disabled {
+  cursor: default;
+  pointer-events: none;
 }

--- a/libs/shared/pagination/ui/ui-pagination.tsx
+++ b/libs/shared/pagination/ui/ui-pagination.tsx
@@ -29,13 +29,17 @@ export default function UiPagination({
       <div className={cx('content')}>
         <Link
           href={`${pathname}?page=${page - 1}`}
-          className={cx('arrow', { disabled: !prevAble })}
+          className={cx({ disabled: !prevAble })}
         >
           <UiPaginationArrow direction="prev" able={prevAble} />
         </Link>
         <div className={cx('numbers')}>
           {shownPages.map((num) => (
-            <Link key={num} href={`${pathname}?page=${num}`}>
+            <Link
+              key={num}
+              href={`${pathname}?page=${num}`}
+              className={cx({ disabled: page === num })}
+            >
               <span className={cx('number', { isActive: page === num })}>
                 {num}
               </span>
@@ -44,7 +48,7 @@ export default function UiPagination({
         </div>
         <Link
           href={`${pathname}?page=${page + 1}`}
-          className={cx('arrow', { disabled: !nextAble })}
+          className={cx({ disabled: !nextAble })}
         >
           <UiPaginationArrow direction="next" able={nextAble} />
         </Link>

--- a/libs/shared/table/feature/tables.tsx
+++ b/libs/shared/table/feature/tables.tsx
@@ -5,6 +5,7 @@ import {
   ApplicationHistoryTableProps,
   TableData,
 } from '@/libs/shared/table/type-table'
+import UiNoTableData from '@/libs/shared/table/ui/ui-no-table-data'
 import UiTableBody from '@/libs/shared/table/ui/ui-table-composition/ui-table-body'
 import UiTableBodyCell from '@/libs/shared/table/ui/ui-table-composition/ui-table-body-cell'
 import UiTableBodyRow from '@/libs/shared/table/ui/ui-table-composition/ui-table-body-row'
@@ -32,14 +33,17 @@ function ApplicationHistoryTable({
   data,
   paginationElement,
 }: ApplicationHistoryTableProps) {
-  const tableData: TableData[] = data.map((item) => ({
-    id: item.id,
-    status: item.status,
-    first: item.name,
-    second: utilFormatDuration(item.startsAt, item.workhour),
-    third: `${item.hourlyPay.toLocaleString()}원`,
-  }))
+  const tableData: TableData[] = data
+    .map((item) => ({
+      id: item.id,
+      status: item.status,
+      first: item.name,
+      second: utilFormatDuration(item.startsAt, item.workhour),
+      third: `${item.hourlyPay.toLocaleString()}원`,
+    }))
+    .filter((item) => item.status !== 'canceled')
 
+  if (!(tableData.length > 0)) return <UiNoTableData userType="employee" />
   return (
     <UiTableContainer paginationElement={paginationElement}>
       <UiTableHeadRow>
@@ -82,15 +86,21 @@ function ApplicantListTable({
   shopId,
   noticeId,
   paginationElement,
+  page,
 }: ApplicantListTableProps) {
-  const tableData: TableData[] = data.map((item) => ({
-    id: item.id,
-    status: item.status,
-    first: item.name,
-    second: item.description,
-    third: item.phone && utilFormatPhone(item.phone),
-  }))
+  const tableData: TableData[] = data
+    .map((item) => ({
+      id: item.id,
+      status: item.status,
+      first: item.name,
+      second: item.description,
+      third: item.phone && utilFormatPhone(item.phone),
+    }))
+    .filter((item) => item.status !== 'canceled')
 
+  if (!(tableData.length > 0)) {
+    return <UiNoTableData userType="employer" checkPage={page !== 1} />
+  }
   return (
     <UiTableContainer paginationElement={paginationElement}>
       <UiTableHeadRow>

--- a/libs/shared/table/type-table.ts
+++ b/libs/shared/table/type-table.ts
@@ -4,6 +4,7 @@ const STATUS = {
   Pending: 'pending',
   Accepted: 'accepted',
   Rejected: 'rejected',
+  Canceled: 'canceled',
 } as const
 export type Status = (typeof STATUS)[keyof typeof STATUS]
 
@@ -40,6 +41,7 @@ export interface ApplicantListTableProps {
   shopId: string
   noticeId: string
   paginationElement: ReactNode
+  page: number
 }
 
 export interface TableData {

--- a/libs/shared/table/ui/ui-no-table-data.module.scss
+++ b/libs/shared/table/ui/ui-no-table-data.module.scss
@@ -1,0 +1,11 @@
+@use '@/styles/utils';
+
+.wrapper {
+  @include utils.flexbox(column);
+
+  width: 100%;
+  height: 100px;
+  color: utils.$gray-brt1;
+  font-size: 20px;
+  gap: 20px;
+}

--- a/libs/shared/table/ui/ui-no-table-data.tsx
+++ b/libs/shared/table/ui/ui-no-table-data.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import classnames from 'classnames/bind'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import { UserType } from '@/libs/shared/table/type-table'
+
+import styles from './ui-no-table-data.module.scss'
+
+const cx = classnames.bind(styles)
+
+const TEXT_MAP = {
+  checkPage: '데이터를 찾지 못했습니다. 페이지를 확인해 주세요.',
+  noData: {
+    employee: '아직 신청 내역이 없어요.',
+    employer: '아직 신청자가 없어요.',
+  },
+}
+
+export default function UiNoTableData({
+  checkPage = true,
+  userType,
+}: {
+  checkPage?: boolean
+  userType: UserType
+}) {
+  const pathname = usePathname()
+  return (
+    <div className={cx('wrapper')}>
+      <span>{checkPage ? TEXT_MAP.checkPage : TEXT_MAP.noData[userType]}</span>
+      {checkPage && (
+        <Link href={`${pathname}?page=1`}>1번 페이지로 이동하기</Link>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- FIX : 버그 수정

## 설명

테이블 데이터 없을 때 UI 구현 및 일부 로직 수정

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #152 

### Key Changes

- 쿼리 파람으로 들어간 page 값이 너무 클 때 or 아예 신청자 목록/신청 내역이 없을 때의 UI 구현
- 테이블 status 타입에 canceled 추가하고 테이블에 나타나지 않도록 필터 처리
- 페이지네이션 로직 및 스타일 일부 수정

### How it Works

아래래와 같이 page에 너무 큰 값을 직접 넣어 데이터가 없을 때 1번 페이지로 돌아갈 수 있도록 UI를 구현했습니다. 
혹은 page=1인데도 데이터가 없을 때는 신청자 목록/신청 내역이 없다고 표시합니다.

![image](https://github.com/codeit-bootcamp-frontend/0-the-julge-young-developers/assets/125791542/a4c5beec-2ff2-451b-8575-79477887afda)


### To Reviewers

- 애매하거나 같이 얘기해보고 싶은 부분
