### PR TITLE
사장 페이지 - 공고 등록 및 무한 스크롤

### DIFF
--- a/app/(main)/my-shop/page.tsx
+++ b/app/(main)/my-shop/page.tsx
@@ -24,7 +24,7 @@ export default async function MyShopPage() {
   return (
     <div>
       <MyShop shopId={shopId || ''} />
-      <MyNoticeList shopId={shopId || ''} />
+      {shopId && <MyNoticeList shopId={shopId || ''} />}
     </div>
   )
 }

--- a/app/(main)/my-shop/page.tsx
+++ b/app/(main)/my-shop/page.tsx
@@ -24,9 +24,7 @@ export default async function MyShopPage() {
   return (
     <div>
       <MyShop shopId={shopId || ''} />
-      <MyNoticeList
-      // shopId={shopId || ''}
-      />
+      <MyNoticeList shopId={shopId || ''} />
     </div>
   )
 }

--- a/app/(main)/my-shop/page.tsx
+++ b/app/(main)/my-shop/page.tsx
@@ -20,7 +20,7 @@ export default async function MyShopPage() {
     return null
   }
   const shopId = userInfo.item.shop?.item.id
-
+  console.log(shopId)
   return (
     <div>
       <MyShop shopId={shopId || ''} />

--- a/libs/my-shop/data-access/data-access-send-notice-request.tsx
+++ b/libs/my-shop/data-access/data-access-send-notice-request.tsx
@@ -1,0 +1,24 @@
+import { registerShopNotice } from '@/libs/shared/api/data-access/request/noticeRequest'
+import { RegisterdShopNoticeProps } from '@/libs/shared/api/types/type-notice'
+
+export async function sendNoticeRequest({
+  shopId,
+  hourlyPay,
+  startsAt,
+  workhour,
+  description,
+}: RegisterdShopNoticeProps): Promise<boolean> {
+  const response = await registerShopNotice({
+    shopId,
+    hourlyPay,
+    startsAt,
+    workhour,
+    description,
+  })
+  console.log(response)
+
+  if (typeof response !== 'string' && !(response instanceof Error)) {
+    return true
+  }
+  return false
+}

--- a/libs/my-shop/data-access/my-notice-data.tsx
+++ b/libs/my-shop/data-access/my-notice-data.tsx
@@ -16,3 +16,348 @@ export const FUNNEL_NOTICE_TITLE = {
     text: '공고에 대한 부가 설명을 적어주세요',
   },
 }
+
+export const MOCK_DATA_NOTICES = {
+  offset: 0,
+  limit: 10,
+  items: [
+    {
+      item: {
+        id: 'bea71379-e6f0-4785-a124-944368362f9c',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/bea71379-e6f0-4785-a124-944368362f9c',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/bea71379-e6f0-4785-a124-944368362f9c',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '0d5dd6f0-5306-4060-8e92-11eff1e36bed',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/0d5dd6f0-5306-4060-8e92-11eff1e36bed',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/0d5dd6f0-5306-4060-8e92-11eff1e36bed',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '33435f79-691a-4c38-b740-b65c47aa91c4',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/33435f79-691a-4c38-b740-b65c47aa91c4',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/33435f79-691a-4c38-b740-b65c47aa91c4',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '72ee0b06-b776-4e7f-a76d-47df50528b31',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/72ee0b06-b776-4e7f-a76d-47df50528b31',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/72ee0b06-b776-4e7f-a76d-47df50528b31',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '60cc1e99-1127-462a-b363-2cc93ba64000',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/60cc1e99-1127-462a-b363-2cc93ba64000',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/60cc1e99-1127-462a-b363-2cc93ba64000',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '61c1eba3-c5fb-4bd0-bdeb-2ca64fba5744',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/61c1eba3-c5fb-4bd0-bdeb-2ca64fba5744',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/61c1eba3-c5fb-4bd0-bdeb-2ca64fba5744',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '2a46df33-0056-4d0f-ae1e-373a8ee9f9f1',
+        hourlyPay: 31000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 2,
+        description: '어서 오세요',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/2a46df33-0056-4d0f-ae1e-373a8ee9f9f1',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/2a46df33-0056-4d0f-ae1e-373a8ee9f9f1',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '82ce2769-a9d7-448e-b638-11c502dc03c8',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/82ce2769-a9d7-448e-b638-11c502dc03c8',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/82ce2769-a9d7-448e-b638-11c502dc03c8',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: '92d59c95-880a-4658-a16e-156ced02fbae',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/92d59c95-880a-4658-a16e-156ced02fbae',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/92d59c95-880a-4658-a16e-156ced02fbae',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: 'db170254-b254-49ea-90aa-fc491630550e',
+        hourlyPay: 10000,
+        startsAt: '2023-09-14T18:00:00.000Z',
+        workhour: 4,
+        description: '테스트',
+        closed: false,
+      },
+      links: [
+        {
+          rel: 'self',
+          description: '공고 정보',
+          method: 'GET',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/db170254-b254-49ea-90aa-fc491630550e',
+        },
+        {
+          rel: 'update',
+          description: '공고 수정',
+          method: 'PUT',
+          href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices/db170254-b254-49ea-90aa-fc491630550e',
+          body: {
+            hourlyPay: 'number',
+            startsAt: 'string',
+            workhour: 'number',
+            description: 'string',
+          },
+        },
+      ],
+    },
+  ],
+  links: [
+    {
+      rel: 'self', // 실제 api에 오타있는 듯..
+      description: '현재 페이지',
+      method: 'GET',
+      href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices?offset=0&limit=10',
+    },
+    {
+      rel: 'prev',
+      description: '이전 페이지',
+      method: 'GET',
+      href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices?offset=0&limit=10',
+    },
+    {
+      rel: 'next',
+      description: '다음 페이지',
+      method: 'GET',
+      href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices?offset=10&limit=10',
+    },
+    {
+      rel: 'create',
+      description: '공고 생성',
+      method: 'POST',
+      href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47/notices',
+      body: {
+        hourlyPay: 'number',
+        startsAt: 'string',
+        workhour: 'number',
+        description: 'string',
+      },
+    },
+    {
+      rel: 'shop',
+      description: '가게 정보',
+      method: 'GET',
+      href: '/api/0-1/the-julge/shops/4490151c-5217-4157-b072-9c37b05bed47',
+    },
+  ],
+}

--- a/libs/my-shop/data-access/my-notice-data.tsx
+++ b/libs/my-shop/data-access/my-notice-data.tsx
@@ -8,7 +8,7 @@ export const FUNNEL_NOTICE_TITLE = {
     text: '업무 시작 일시를 입력해 주세요',
   },
   workhour: {
-    title: '주소',
+    title: '업무 시간',
     text: '업무 시간을 입력해 주세요',
   },
   description: {

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -51,6 +51,7 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
       setCount(newCount)
 
       setOffset((prev) => prev + 3)
+      setInView(false)
     }
     return true
   }
@@ -72,7 +73,6 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
   }, [])
 
   useEffect(() => {
-    console.log(inView, offset, count)
     if (!isLoading) {
       fetchNotices()
     }

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -96,7 +96,7 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
           <UnregisteredMyNotice />
         )}
       </UiSimpleLayout>
-      <div ref={lastItemRef}> 왜 안돼 </div>
+      <div ref={lastItemRef} style={{ height: '1px' }} />
     </div>
   )
 }

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -11,11 +11,11 @@ import NoticeCardList from './notice-card-list'
 export default async function MyNoticeList({ shopId }: { shopId: string }) {
   const noticeData = await getShopNotices({
     shopId,
-    // offset: 0,
-    // limit: 10,
+    offset: 0,
+    limit: 10,
   })
   if (noticeData) {
-    console.log(noticeData)
+    console.log(shopId, noticeData)
   }
   return (
     <div>

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -5,17 +5,25 @@ import { ShopNoticesData } from '@/libs/shared/api/types/type-notice'
 import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
 import NoticeCardList from './notice-card-list'
-
-// import UnregisteredMyNotice from './unregistered-notice'
+import UnregisteredMyNotice from './unregistered-notice'
 
 export default async function MyNoticeList({ shopId }: { shopId: string }) {
-  const noticeData = await getShopNotices({
+  const response = await getShopNotices({
     shopId,
     offset: 0,
     limit: 10,
   })
-  if (noticeData) {
-    console.log(shopId, noticeData)
+
+  let noticeData
+  let count = 0
+  if (response instanceof Error) {
+    // 알 수 없는 에러 처리
+  } else if (typeof response === 'string') {
+    // 에러 메시지에 맞게 처리
+  } else {
+    // response 데이터 가공
+    noticeData = response
+    count = noticeData.count
   }
   return (
     <div>
@@ -25,11 +33,14 @@ export default async function MyNoticeList({ shopId }: { shopId: string }) {
         titleSize={28}
         gap={24}
       >
-        {/* <UnregisteredMyNotice /> */}
-        <NoticeCardList
-          shopId={shopId}
-          notices={noticeData as ShopNoticesData}
-        />
+        {count !== 0 ? (
+          <NoticeCardList
+            shopId={shopId}
+            notices={noticeData as ShopNoticesData}
+          />
+        ) : (
+          <UnregisteredMyNotice />
+        )}
       </UiSimpleLayout>
     </div>
   )

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -1,10 +1,22 @@
 import React from 'react'
 
+import { getShopNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
+import { ShopNoticesData } from '@/libs/shared/api/types/type-notice'
 import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
-import UnregisteredMyNotice from './unregistered-notice'
+import NoticeCardList from './notice-card-list'
 
-export default function MyNoticeList() {
+// import UnregisteredMyNotice from './unregistered-notice'
+
+export default async function MyNoticeList({ shopId }: { shopId: string }) {
+  const noticeData = await getShopNotices({
+    shopId,
+    // offset: 0,
+    // limit: 10,
+  })
+  if (noticeData) {
+    console.log(noticeData)
+  }
   return (
     <div>
       <UiSimpleLayout
@@ -13,7 +25,11 @@ export default function MyNoticeList() {
         titleSize={28}
         gap={24}
       >
-        <UnregisteredMyNotice />
+        {/* <UnregisteredMyNotice /> */}
+        <NoticeCardList
+          shopId={shopId}
+          notices={noticeData as ShopNoticesData}
+        />
       </UiSimpleLayout>
     </div>
   )

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -1,30 +1,83 @@
-import React from 'react'
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
 
 import { getShopNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
 import { ShopNoticesData } from '@/libs/shared/api/types/type-notice'
+import UiLoading from '@/libs/shared/loading/ui/ui-loading'
 import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
 import NoticeCardList from './notice-card-list'
 import UnregisteredMyNotice from './unregistered-notice'
 
-export default async function MyNoticeList({ shopId }: { shopId: string }) {
-  const response = await getShopNotices({
-    shopId,
-    offset: 0,
-    limit: 10,
-  })
+export default function MyNoticeList({ shopId }: { shopId: string }) {
+  const [offset, setOffset] = useState<number>(0)
+  const [noticeData, setNoticeData] = useState<ShopNoticesData | undefined>()
+  const [count, setCount] = useState(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const [inView, setInView] = useState(false)
+  const lastItemRef = useRef<HTMLDivElement>(null)
 
-  let noticeData
-  let count = 0
-  if (response instanceof Error) {
-    // 알 수 없는 에러 처리
-  } else if (typeof response === 'string') {
-    // 에러 메시지에 맞게 처리
-  } else {
-    // response 데이터 가공
-    noticeData = response
-    count = noticeData.count
+  async function fetchNotices() {
+    setIsLoading(true)
+    const response = await getShopNotices({
+      shopId,
+      offset,
+      limit: 3,
+    })
+    setIsLoading(false)
+
+    if (response instanceof Error) {
+      // 알 수 없는 에러 처리
+      return false
+    }
+    if (typeof response === 'string') {
+      // 에러 메시지에 따른 에러 처리
+      return false
+    }
+    const newNoticeData = response
+    const newCount = newNoticeData.count
+    if (offset > count || isLoading) {
+      return
+    }
+    if (newNoticeData.items && newNoticeData.items.length > 0) {
+      if (noticeData) {
+        const mergedItems = [...noticeData.items, ...newNoticeData.items]
+        newNoticeData.items = mergedItems
+        setNoticeData(newNoticeData)
+      }
+
+      setNoticeData(newNoticeData)
+      setCount(newCount)
+
+      setOffset((prev) => prev + 3)
+    }
+    return true
   }
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setInView(true)
+        } else {
+          setInView(false)
+        }
+      },
+      { threshold: 1 },
+    )
+    if (lastItemRef.current) {
+      observer.observe(lastItemRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    console.log(inView, offset, count)
+    if (!isLoading) {
+      fetchNotices()
+    }
+  }, [inView])
+
   return (
     <div>
       <UiSimpleLayout
@@ -33,15 +86,17 @@ export default async function MyNoticeList({ shopId }: { shopId: string }) {
         titleSize={28}
         gap={24}
       >
-        {count !== 0 ? (
-          <NoticeCardList
-            shopId={shopId}
-            notices={noticeData as ShopNoticesData}
-          />
+        {count !== 0 && noticeData ? (
+          <>
+            <NoticeCardList shopId={shopId} notices={noticeData} />
+
+            {isLoading && <UiLoading />}
+          </>
         ) : (
           <UnregisteredMyNotice />
         )}
       </UiSimpleLayout>
+      <div ref={lastItemRef}> 왜 안돼 </div>
     </div>
   )
 }

--- a/libs/my-shop/feature/my-notice/notice-card-list.tsx
+++ b/libs/my-shop/feature/my-notice/notice-card-list.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import { getShopInfo } from '@/libs/shared/api/data-access/request/shopRequest'
+import {
+  AllNoticesData,
+  ShopNoticesData,
+} from '@/libs/shared/api/types/type-notice'
+import { ShopData } from '@/libs/shared/api/types/type-shop'
+import NoticeCardItem from '@/libs/shared/notice-card/feature/notice-card-item'
+
+export default async function NoticeCardList({
+  notices,
+  shopId,
+}: {
+  notices: ShopNoticesData
+  shopId: string
+}) {
+  const myShopData = (await getShopInfo(shopId)) as ShopData
+
+  const data: AllNoticesData[] = notices.items.map((item) => {
+    const shop = myShopData?.item // myShopData가 존재하면 shop 변수에 할당
+    return {
+      ...item.item, // 기존의 item.item을 그대로 유지
+      shop: {
+        item: {
+          id: shop?.id ?? '',
+          name: shop?.name ?? '',
+          category: shop?.category ?? '',
+          address1: shop?.address1 ?? '',
+          address2: shop?.address2 ?? '',
+          description: shop?.description ?? '',
+          imageUrl: shop?.imageUrl ?? '',
+          originalHourlyPay: shop?.originalHourlyPay ?? 0,
+        },
+        href: myShopData.links[0].href,
+      },
+    }
+  })
+
+  return (
+    <div>
+      <NoticeCardItem title="등록한 공고" data={data} />
+    </div>
+  )
+}

--- a/libs/my-shop/feature/my-notice/notice-card-list.tsx
+++ b/libs/my-shop/feature/my-notice/notice-card-list.tsx
@@ -16,7 +16,6 @@ export default async function NoticeCardList({
   shopId: string
 }) {
   const myShopData = (await getShopInfo(shopId)) as ShopData
-
   const data: AllNoticesData[] = notices.items.map((item) => {
     const shop = myShopData?.item // myShopData가 존재하면 shop 변수에 할당
     return {

--- a/libs/my-shop/feature/my-notice/notice-card-list.tsx
+++ b/libs/my-shop/feature/my-notice/notice-card-list.tsx
@@ -1,4 +1,6 @@
-import React from 'react'
+'use client'
+
+import React, { useEffect, useState } from 'react'
 
 import { getShopInfo } from '@/libs/shared/api/data-access/request/shopRequest'
 import {
@@ -8,18 +10,32 @@ import {
 import { ShopData } from '@/libs/shared/api/types/type-shop'
 import NoticeCardItem from '@/libs/shared/notice-card/feature/notice-card-item'
 
-export default async function NoticeCardList({
+export default function NoticeCardList({
   notices,
   shopId,
 }: {
   notices: ShopNoticesData
   shopId: string
 }) {
-  const myShopData = (await getShopInfo(shopId)) as ShopData
+  const [myShopData, setMyShopData] = useState<ShopData | null>(null)
+
+  useEffect(() => {
+    async function fetchShopData() {
+      const response = await getShopInfo(shopId)
+      if (response instanceof Error) {
+        // Handle error
+      } else {
+        setMyShopData(response as ShopData)
+      }
+    }
+
+    fetchShopData()
+  }, [shopId])
+
   const data: AllNoticesData[] = notices.items.map((item) => {
-    const shop = myShopData?.item // myShopData가 존재하면 shop 변수에 할당
+    const shop = myShopData?.item
     return {
-      ...item.item, // 기존의 item.item을 그대로 유지
+      ...item.item,
       shop: {
         item: {
           id: shop?.id ?? '',
@@ -31,7 +47,7 @@ export default async function NoticeCardList({
           imageUrl: shop?.imageUrl ?? '',
           originalHourlyPay: shop?.originalHourlyPay ?? 0,
         },
-        href: myShopData.links[0].href,
+        href: myShopData?.links[0].href ?? '',
       },
     }
   })

--- a/libs/my-shop/feature/my-notice/notice-card-list.tsx
+++ b/libs/my-shop/feature/my-notice/notice-card-list.tsx
@@ -39,7 +39,7 @@ export default async function NoticeCardList({
 
   return (
     <div>
-      <NoticeCardItem title="등록한 공고" data={data} />
+      <NoticeCardItem data={data} />
     </div>
   )
 }

--- a/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
+++ b/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
@@ -9,6 +9,7 @@ import {
   ActiveBtn,
   InactiveBtn,
 } from '@/libs/shared/click-btns/feature/click-btns'
+import SelectDatePicker from '@/libs/shared/input-select-btn/feature/feature-date-picker'
 import Input from '@/libs/shared/input-select-btn/feature/feature-input'
 import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
@@ -24,7 +25,7 @@ export default function RegisterNoticeDefaultContent({
   const {
     // hourlyWage,
     setHourlyWage,
-    // startsAt,
+    startsAt,
     setStartsAt,
     // workhour,
     setWorkhour,
@@ -48,12 +49,10 @@ export default function RegisterNoticeDefaultContent({
               />
             </div>
             <div className={cx('inputTopItem')}>
-              <Input
-                onChange={(e) => setStartsAt(e.target.value)}
-                variant="input"
+              <SelectDatePicker
                 title="시작 일시*"
-                isValid={false}
-                isRequired={false}
+                onSelectDate={setStartsAt}
+                selectedDate={startsAt}
               />
             </div>
             <div className={cx('inputTopItem')}>

--- a/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
+++ b/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
@@ -1,6 +1,11 @@
-import React from 'react'
+'use client'
+
+import { MouseEvent, useState } from 'react'
 
 import classNames from 'classnames/bind'
+import { getCookie } from 'cookies-next'
+
+import { useRouter } from 'next/navigation'
 
 import styles from '@/libs/alba/my-profile/my-profile-h/feature/register-modal.module.scss'
 import useRegisterNoticeState from '@/libs/my-shop/utill/useRegisterNoticeState'
@@ -11,7 +16,10 @@ import {
 } from '@/libs/shared/click-btns/feature/click-btns'
 import SelectDatePicker from '@/libs/shared/input-select-btn/feature/feature-date-picker'
 import Input from '@/libs/shared/input-select-btn/feature/feature-input'
+import UiLoading from '@/libs/shared/loading/ui/ui-loading'
 import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
+
+import { sendNoticeRequest } from '../../data-access/data-access-send-notice-request'
 
 const cx = classNames.bind(styles)
 
@@ -22,74 +30,103 @@ export default function RegisterNoticeDefaultContent({
   showModal: boolean
   onClickToggelModal: () => void
 }) {
+  const [isLoading, setISLoading] = useState(false)
+  const router = useRouter()
   const {
-    // hourlyWage,
+    hourlyWage,
     setHourlyWage,
     startsAt,
     setStartsAt,
-    // workhour,
+    workhour,
     setWorkhour,
-    // description,
+    description,
     setDescription,
     isAllFilled,
-    // setIsAllFilled,
   } = useRegisterNoticeState()
+
+  const handleSubmit = async (e: MouseEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    console.log('ㅋㅋ')
+    const sid = getCookie('sid')
+    if (!startsAt) {
+      return
+    }
+    setISLoading(true)
+    const isSuccess = await sendNoticeRequest({
+      shopId: `${sid}`,
+      hourlyPay: hourlyWage as number,
+      startsAt: startsAt.toISOString(),
+      workhour: workhour as number,
+      description,
+    })
+    console.log(isSuccess)
+    if (isSuccess) {
+      setISLoading(false)
+      onClickToggelModal()
+      router.refresh()
+    } else {
+      setISLoading(false)
+      // 실패의 경우 처리
+    }
+  }
+
+  const renderSubmitButton = () => {
+    if (!isAllFilled) {
+      return <InactiveBtn text="등록하기" size="large" />
+    }
+
+    if (isLoading) {
+      return <UiLoading />
+    }
+
+    return <ActiveBtn text="등록하기" size="large" type="submit" />
+  }
+
   return (
     <div className={cx('modalWrapper', { showModal })}>
       <UiBgGrayModal onClickCloseModal={onClickToggelModal}>
         <UiSimpleLayout title="공고 등록" gap={24}>
-          <div className={cx('inputTopWrapper')}>
-            <div className={cx('inputTopItem')}>
+          <form onSubmit={handleSubmit}>
+            <div className={cx('inputTopWrapper')}>
+              <div className={cx('inputTopItem')}>
+                <Input
+                  onChange={(e) => setHourlyWage(Number(e.target.value))}
+                  variant="input"
+                  title="시급*"
+                  isValid={false}
+                  isRequired={false}
+                />
+              </div>
+              <div className={cx('inputTopItem')}>
+                <SelectDatePicker
+                  title="시작 일시*"
+                  onSelectDate={setStartsAt}
+                  selectedDate={startsAt}
+                />
+              </div>
+              <div className={cx('inputTopItem')}>
+                {/* date picker? */}
+                <Input
+                  onChange={(e) => setWorkhour(Number(e.target.value))}
+                  variant="input"
+                  title="업무 시간*"
+                  isValid={false}
+                  isRequired={false}
+                  suffix="시간"
+                />
+              </div>
+            </div>
+            <div className={cx('inputBottomItem')}>
               <Input
-                onChange={(e) => setHourlyWage(e.target.value)}
-                variant="input"
-                title="시급*"
+                onChange={(e) => setDescription(e.target.value)}
+                variant="explain"
+                title="공고 설명*"
                 isValid={false}
                 isRequired={false}
               />
             </div>
-            <div className={cx('inputTopItem')}>
-              <SelectDatePicker
-                title="시작 일시*"
-                onSelectDate={setStartsAt}
-                selectedDate={startsAt}
-              />
-            </div>
-            <div className={cx('inputTopItem')}>
-              {/* date picker? */}
-              <Input
-                onChange={(e) => setWorkhour(e.target.value)}
-                variant="input"
-                title="업무 시간*"
-                isValid={false}
-                isRequired={false}
-              />
-            </div>
-          </div>
-          <div className={cx('inputBottomItem')}>
-            <Input
-              onChange={(e) => setDescription(e.target.value)}
-              variant="explain"
-              title="공고 설명*"
-              isValid={false}
-              isRequired={false}
-            />
-          </div>
-          <div className={cx('btnWrapper')}>
-            {isAllFilled ? (
-              <ActiveBtn
-                text="등록하기"
-                size="large"
-                onClick={() => console.log('등록하기')}
-              />
-            ) : (
-              <InactiveBtn
-                text="등록하기"
-                size="large"
-                onClick={() => console.log('안 등록하기')}
-              />
-            )}
-          </div>
+            <div className={cx('btnWrapper')}>{renderSubmitButton()}</div>
+          </form>
         </UiSimpleLayout>
       </UiBgGrayModal>
     </div>

--- a/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
+++ b/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
@@ -46,7 +46,6 @@ export default function RegisterNoticeDefaultContent({
 
   const handleSubmit = async (e: MouseEvent<HTMLFormElement>) => {
     e.preventDefault()
-    console.log('ㅋㅋ')
     const sid = getCookie('sid')
     if (!startsAt) {
       return

--- a/libs/my-shop/feature/my-notice/unregistered-notice.tsx
+++ b/libs/my-shop/feature/my-notice/unregistered-notice.tsx
@@ -1,22 +1,14 @@
 import React from 'react'
 
 import UiRegisterLayout from '@/libs/shared/register-layout/ui/ui-register-layout'
-import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
 import RegisterNoticeBtn from './register-notice-btn'
 
 export default function UnregisteredMyNotice() {
   return (
-    <UiSimpleLayout
-      title="등록한 공고"
-      titleAlign="start"
-      titleSize={28}
-      gap={24}
-    >
-      <UiRegisterLayout
-        text="공고를 등록해 보세요."
-        registerButton={<RegisterNoticeBtn />}
-      />
-    </UiSimpleLayout>
+    <UiRegisterLayout
+      text="공고를 등록해 보세요."
+      registerButton={<RegisterNoticeBtn />}
+    />
   )
 }

--- a/libs/my-shop/feature/my-notice/unregistered-notice.tsx
+++ b/libs/my-shop/feature/my-notice/unregistered-notice.tsx
@@ -1,14 +1,22 @@
 import React from 'react'
 
 import UiRegisterLayout from '@/libs/shared/register-layout/ui/ui-register-layout'
+import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
 import RegisterNoticeBtn from './register-notice-btn'
 
 export default function UnregisteredMyNotice() {
   return (
-    <UiRegisterLayout
-      text="공고를 등록해 보세요."
-      registerButton={<RegisterNoticeBtn />}
-    />
+    <UiSimpleLayout
+      title="등록한 공고"
+      titleAlign="start"
+      titleSize={28}
+      gap={24}
+    >
+      <UiRegisterLayout
+        text="공고를 등록해 보세요."
+        registerButton={<RegisterNoticeBtn />}
+      />
+    </UiSimpleLayout>
   )
 }

--- a/libs/my-shop/feature/my-shop/register-shop-modal-default-contnet.tsx
+++ b/libs/my-shop/feature/my-shop/register-shop-modal-default-contnet.tsx
@@ -67,7 +67,6 @@ export default function RegisterShopModalDefaultContent({
       selectedImage,
       description,
     )
-    console.log(isSuccess)
     if (isSuccess) {
       setISLoading(false)
       onClickToggelModal()

--- a/libs/my-shop/feature/my-shop/register-shop-modal-funnel-content.tsx
+++ b/libs/my-shop/feature/my-shop/register-shop-modal-funnel-content.tsx
@@ -122,7 +122,6 @@ export default function RegisterShopModalFunnelContent({
       selectedImage,
       description,
     )
-    console.log(isSuccess)
     if (isSuccess) {
       setISLoading(false)
       onClickToggelModal()

--- a/libs/my-shop/utill/useRegisterNoticeState.tsx
+++ b/libs/my-shop/utill/useRegisterNoticeState.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react'
 
 export default function useRegisterNoticeState(variant = 'default') {
-  const [hourlyWage, setHourlyWage] = useState<string>('')
+  const [hourlyWage, setHourlyWage] = useState<number>()
   const [startsAt, setStartsAt] = useState<Date | undefined>()
-  const [workhour, setWorkhour] = useState<string>('')
+  const [workhour, setWorkhour] = useState<number>()
   const [description, setDescription] = useState<string>('')
   const [isAllFilled, setIsAllFilled] = useState<boolean>(false)
 

--- a/libs/my-shop/utill/useRegisterNoticeState.tsx
+++ b/libs/my-shop/utill/useRegisterNoticeState.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 export default function useRegisterNoticeState(variant = 'default') {
   const [hourlyWage, setHourlyWage] = useState<string>('')
-  const [startsAt, setStartsAt] = useState<string>('')
+  const [startsAt, setStartsAt] = useState<Date | undefined>()
   const [workhour, setWorkhour] = useState<string>('')
   const [description, setDescription] = useState<string>('')
   const [isAllFilled, setIsAllFilled] = useState<boolean>(false)

--- a/libs/my-shop/utill/userIntersectionObserver.tsx
+++ b/libs/my-shop/utill/userIntersectionObserver.tsx
@@ -1,0 +1,26 @@
+import { useRef } from 'react'
+
+export default function useIntersectionObserver(callback: () => void) {
+  const observer = useRef(
+    new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            callback()
+          }
+        })
+      },
+      { threshold: 1 },
+    ),
+  )
+
+  const observe = (element: HTMLDivElement) => {
+    observer.current.observe(element)
+  }
+
+  const unobserve = (element: HTMLDivElement) => {
+    observer.current.unobserve(element)
+  }
+
+  return [observe, unobserve]
+}

--- a/libs/notice-detail-alice/ui/ui-recent-notices.tsx
+++ b/libs/notice-detail-alice/ui/ui-recent-notices.tsx
@@ -15,7 +15,9 @@ export default function UiRecentNotices({
 }) {
   return (
     <div className={cx('recentNotices')}>
-      {noticesList && <NoticeCardItem data={noticesList} />}
+      {noticesList && (
+        <NoticeCardItem title="최근에 본 공고" data={noticesList} />
+      )}
     </div>
   )
 }

--- a/libs/shared/detail-filter/feature/detail-filter.tsx
+++ b/libs/shared/detail-filter/feature/detail-filter.tsx
@@ -47,9 +47,6 @@ export default function DetailFilter({
       startInputRef.current?.value,
       numberPrice,
     )
-    console.log('선택 위치:', selectedLocations)
-    console.log('시작일:', startInputRef.current?.value)
-    console.log('금액:', priceInputRef.current?.value)
     onClickCloseButton(false)
   }
 

--- a/libs/shared/input-select-btn/feature/feature-date-picker.tsx
+++ b/libs/shared/input-select-btn/feature/feature-date-picker.tsx
@@ -16,8 +16,8 @@ export default function SelectDatePicker({
   selectedDate,
   title,
 }: {
-  onSelectDate: Dispatch<SetStateAction<Date>>
-  selectedDate: Date
+  onSelectDate: Dispatch<SetStateAction<Date | undefined>>
+  selectedDate: Date | undefined
   title: string
 }) {
   const handleDateChange = (date: Date) => {

--- a/libs/shared/input-select-btn/feature/feature-date-picker.tsx
+++ b/libs/shared/input-select-btn/feature/feature-date-picker.tsx
@@ -22,7 +22,6 @@ export default function SelectDatePicker({
 }) {
   const handleDateChange = (date: Date) => {
     onSelectDate(date)
-    console.log(date)
   }
   return (
     <div className={cx('wrapper')}>

--- a/libs/shared/notice-card/feature/notice-card-item.tsx
+++ b/libs/shared/notice-card/feature/notice-card-item.tsx
@@ -21,6 +21,7 @@ export default function NoticeCardItem({
   filterElement?: React.ReactNode
 }) {
   const router = useRouter()
+  console.log(title)
 
   const handleClickToDetail = (
     isClosed: boolean,

--- a/libs/shared/notice-card/feature/notice-card-item.tsx
+++ b/libs/shared/notice-card/feature/notice-card-item.tsx
@@ -21,7 +21,6 @@ export default function NoticeCardItem({
   filterElement?: React.ReactNode
 }) {
   const router = useRouter()
-  console.log(title)
 
   const handleClickToDetail = (
     isClosed: boolean,

--- a/libs/shared/notice-card/feature/notice-card-item.tsx
+++ b/libs/shared/notice-card/feature/notice-card-item.tsx
@@ -16,7 +16,7 @@ export default function NoticeCardItem({
   data,
   filterElement,
 }: {
-  title: string
+  title?: string
   data: AllNoticesData[]
   filterElement?: React.ReactNode
 }) {

--- a/libs/shared/notice-card/feature/notice-card-item.tsx
+++ b/libs/shared/notice-card/feature/notice-card-item.tsx
@@ -5,7 +5,6 @@ import { getCookie } from 'cookies-next'
 import { useRouter } from 'next/navigation'
 
 import { AllNoticesData } from '../../api/types/type-notice'
-import { MOCK_DOMAIN } from '../data-access/data-access-mock'
 import UiNoticeCardItem from '../ui/ui-notice-card-item/ui-notice-card-item'
 import UiNoticeCardList from '../ui/ui-notice-card-list/ui-notice-card-list'
 import { utilCalcChangeRate } from '../util/util-calc-change-rate'
@@ -13,9 +12,11 @@ import { utilCalcPayDiff } from '../util/util-calc-pay-diff'
 import { utilFormatDuration } from '../util/util-format-duration'
 
 export default function NoticeCardItem({
+  title,
   data,
   filterElement,
 }: {
+  title: string
   data: AllNoticesData[]
   filterElement?: React.ReactNode
 }) {
@@ -37,14 +38,14 @@ export default function NoticeCardItem({
   }
 
   const itemDatas = data.map((item) => ({
-    name: item.shop.item.name,
+    name: item.shop?.item.name,
     id: item.id,
     duration: utilFormatDuration(item.startsAt, item.workhour),
     workhour: item.workhour,
-    address: item.shop.item.address1,
+    address: item.shop?.item.address1,
     hourlyPay: item.hourlyPay,
-    originalHourlyPay: item.shop.item.originalHourlyPay,
-    imageUrl: item.shop.item.imageUrl,
+    originalHourlyPay: item.shop?.item.originalHourlyPay,
+    imageUrl: item.shop?.item.imageUrl,
     closed: item.closed,
     shopId: item.shop.item.id,
     handleClickToDetail: () =>
@@ -54,7 +55,7 @@ export default function NoticeCardItem({
   return (
     <UiNoticeCardList
       // title prop은 변경 예정입니다.
-      title={MOCK_DOMAIN.title}
+      title={title}
       filterElement={filterElement}
 
       // ref={first}

--- a/libs/shared/notice-card/type-notice-card.ts
+++ b/libs/shared/notice-card/type-notice-card.ts
@@ -52,7 +52,7 @@ export interface UiNoticeCardItemProps {
 }
 
 export interface UiNoticeCardListProps {
-  title: string
+  title?: string
   filterElement?: React.ReactNode
   children: React.ReactNode
 }

--- a/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-card-item/ui-notice-card-item.tsx
@@ -29,7 +29,11 @@ export default function UiNoticeCardItem({
       onClick={onClickToDetail}
     >
       <div className={cx('imgContainer', 'header')}>
-        <img className={cx('img')} src={imageUrl} alt={name} />
+        <img
+          className={cx('img')}
+          src={imageUrl || '/images/default-img.svg'}
+          alt={name}
+        />
         {closed && (
           <div className={cx('closedLayer')}>
             <span className={cx('closedText')}>마감 완료</span>

--- a/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.module.scss
+++ b/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.module.scss
@@ -20,7 +20,6 @@ $card-size-small: 171px;
   width: 100%;
 
   @include utils.tablet {
-    padding: 0 32px;
   }
 
   @include utils.mobile {

--- a/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.tsx
@@ -16,7 +16,7 @@ export default forwardRef(function UiNoticeCardList(
 ) {
   return (
     <div className={cx('wrapper')}>
-      {title && filterElement && (
+      {(title || filterElement) && (
         <div className={cx('titleHeader')}>
           {title && <h2 className={cx('title')}>{title}</h2>}
           {filterElement && (

--- a/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.tsx
+++ b/libs/shared/notice-card/ui/ui-notice-card-list/ui-notice-card-list.tsx
@@ -16,10 +16,14 @@ export default forwardRef(function UiNoticeCardList(
 ) {
   return (
     <div className={cx('wrapper')}>
-      <div className={cx('titleHeader')}>
-        <h2 className={cx('title')}>{title}</h2>
-        <div className={cx('filterElementWrapper')}>{filterElement}</div>
-      </div>
+      {title && filterElement && (
+        <div className={cx('titleHeader')}>
+          {title && <h2 className={cx('title')}>{title}</h2>}
+          {filterElement && (
+            <div className={cx('filterElementWrapper')}>{filterElement}</div>
+          )}
+        </div>
+      )}
       <div className={cx('listWrapper')} ref={ref}>
         {children}
       </div>

--- a/public/images/default-img.svg
+++ b/public/images/default-img.svg
@@ -1,0 +1,3 @@
+<svg width="338" height="210" viewBox="0 0 338 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="338" height="210" fill="#E5E4E7"/>
+</svg>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- FIX : 버그 수정
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정

## 설명
사장페이지 공고 등록 및 공고목록 무한 스크롤로 불러오기를 구현했습니다.


### 이슈 번호
close #126



### Key Changes

- 공고 등록하기 에러 핸들링
- 무한 스크롤



### How it Works

- limit은 현재 3입니다. 추후 10 정도로 변경 예정입니다.


### To Reviewers
- 한번에 몇개의 공고를 불러오는 것이 나을까요?