### PR TITLE
사장 가게 공고 상세 페이지 로딩 처리 & 테이블 canceled 버그 픽스

### DIFF
--- a/app/(main)/my-shop/[id]/page.tsx
+++ b/app/(main)/my-shop/[id]/page.tsx
@@ -1,8 +1,11 @@
+import { Suspense } from 'react'
+
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import { getShopIdData } from '@/libs/my-shop-notice/data-access/data-access-notice'
 import MyShopNoticeApplicant from '@/libs/my-shop-notice/feature/my-shop-notice-applicant'
+import CommonDomainLoader from '@/libs/shared/loading/feature/domain-loader'
 
 export default async function MyShopNoticeDetailPage({
   params,
@@ -23,6 +26,15 @@ export default async function MyShopNoticeDetailPage({
       : Math.floor(Number(searchParams.page))
 
   return (
-    <MyShopNoticeApplicant shopId={shopId} noticeId={params.id} page={page} />
+    <Suspense
+      fallback={
+        <CommonDomainLoader
+          title="신청 목록"
+          text="테이블 정보를 불러오고 있어요"
+        />
+      }
+    >
+      <MyShopNoticeApplicant shopId={shopId} noticeId={params.id} page={page} />
+    </Suspense>
   )
 }

--- a/app/(main)/my-shop/layout.tsx
+++ b/app/(main)/my-shop/layout.tsx
@@ -10,6 +10,9 @@ export default function MyShopLayout({
       {children}
       <div id="funnel-portal-notice" />
       <div id="funnel-portal" />
+      <div id="btn-portal" />
+      <div id="loader-portal" />
+      <div id="toast-portal" />
     </div>
   )
 }

--- a/libs/shared/table/feature/table-status-button.tsx
+++ b/libs/shared/table/feature/table-status-button.tsx
@@ -36,6 +36,7 @@ export default function TableStatusButton({
   const [openClientLoader, setOpenClientLoader] = useState(false)
   const [shownToast, setShownToast] = useState(false)
   const [isRejectDone, setIsRejectDone] = useState(false)
+  const [isAcceptDone, setIsAcceptDone] = useState(false)
 
   const handleClickAcceptApplication = async () => {
     setOpenClientLoader(true)
@@ -49,7 +50,8 @@ export default function TableStatusButton({
 
     setShownToast(true)
     setShownAcceptDialog(false)
-    router.push('/my-shop')
+    setIsAcceptDone(true)
+    setTimeout(() => router.push('/my-shop'), 3000)
   }
 
   const handleClickRejectApplication = async () => {
@@ -75,7 +77,30 @@ export default function TableStatusButton({
     }
   }, [isMobile])
 
-  if (isRejectDone) return <UiTableBodyStatusChip status="rejected" />
+  if (isRejectDone) {
+    return (
+      <>
+        <UiTableBodyStatusChip status="rejected" />
+        {shownToast && (
+          <ToastContainer onShow={() => setShownToast(false)}>
+            거절했어요
+          </ToastContainer>
+        )}
+      </>
+    )
+  }
+  if (isAcceptDone) {
+    return (
+      <>
+        <UiTableBodyStatusChip status="accepted" />
+        {shownToast && (
+          <ToastContainer onShow={() => setShownToast(false)}>
+            승인했어요. 내 가게 페이지로 돌아갑니다.
+          </ToastContainer>
+        )}
+      </>
+    )
+  }
   return (
     <>
       <ActiveOutlineBtn
@@ -109,11 +134,6 @@ export default function TableStatusButton({
         </div>
       )}
       {openClientLoader && <CommonClientLoader />}
-      {shownToast && (
-        <ToastContainer onShow={() => setShownToast(false)}>
-          {shownAcceptDialog ? '승인했어요' : '거절했어요'}
-        </ToastContainer>
-      )}
     </>
   )
 }

--- a/libs/shared/table/feature/table-status-button.tsx
+++ b/libs/shared/table/feature/table-status-button.tsx
@@ -10,11 +10,12 @@ import {
   ActiveOutlineConfirmBtn,
 } from '@/libs/shared/click-btns/feature/click-btns'
 import { ActionDialog } from '@/libs/shared/dialog/feature/dialog'
+import CommonClientLoader from '@/libs/shared/loading/feature/client-loader'
 import { useMediaQuery } from '@/libs/shared/shared/util/useMediaQuery'
 import useOutsideClick from '@/libs/shared/shared/util/useOutsideClick'
 import { TableStatusButtonProps } from '@/libs/shared/table/type-table'
-
-import UiTableBodyStatusChip from '../ui/ui-table-composition/ui-table-body-status-chip'
+import UiTableBodyStatusChip from '@/libs/shared/table/ui/ui-table-composition/ui-table-body-status-chip'
+import ToastContainer from '@/libs/shared/toast/feature/toast-container'
 
 export default function TableStatusButton({
   shopId,
@@ -25,36 +26,45 @@ export default function TableStatusButton({
   const isMobile = useMediaQuery('(max-width: 768px)')
   const [isMobileSize, setIsMobileSize] = useState<boolean>(false)
 
-  const [isRejectDone, setIsRejectDone] = useState(false)
-
   const [shownAcceptDialog, setShownAcceptDialog] = useState(false)
   const [shownRejectDialog, setShownRejectDialog] = useState(false)
-
   const rejectDialogRef = useRef<HTMLDivElement | null>(null)
   const acceptDialogRef = useRef<HTMLDivElement | null>(null)
   useOutsideClick(rejectDialogRef, () => setShownRejectDialog(false))
   useOutsideClick(acceptDialogRef, () => setShownAcceptDialog(false))
 
+  const [openClientLoader, setOpenClientLoader] = useState(false)
+  const [shownToast, setShownToast] = useState(false)
+  const [isRejectDone, setIsRejectDone] = useState(false)
+
   const handleClickAcceptApplication = async () => {
-    setShownAcceptDialog(false)
+    setOpenClientLoader(true)
     await updateNoticeApplicationResult(
       shopId,
       noticeId,
       applicationId,
       'accepted',
     )
+    setOpenClientLoader(false)
+
+    setShownToast(true)
+    setShownAcceptDialog(false)
     router.push('/my-shop')
   }
 
   const handleClickRejectApplication = async () => {
-    setShownRejectDialog(false)
-    setIsRejectDone(true)
+    setOpenClientLoader(true)
     await updateNoticeApplicationResult(
       shopId,
       noticeId,
       applicationId,
       'rejected',
     )
+    setOpenClientLoader(false)
+
+    setShownToast(true)
+    setShownRejectDialog(false)
+    setIsRejectDone(true)
   }
 
   useEffect(() => {
@@ -97,6 +107,12 @@ export default function TableStatusButton({
             onAccept={handleClickAcceptApplication}
           />
         </div>
+      )}
+      {openClientLoader && <CommonClientLoader />}
+      {shownToast && (
+        <ToastContainer onShow={() => setShownToast(false)}>
+          {shownAcceptDialog ? '승인했어요' : '거절했어요'}
+        </ToastContainer>
       )}
     </>
   )

--- a/libs/shared/table/feature/tables.tsx
+++ b/libs/shared/table/feature/tables.tsx
@@ -33,15 +33,13 @@ function ApplicationHistoryTable({
   data,
   paginationElement,
 }: ApplicationHistoryTableProps) {
-  const tableData: TableData[] = data
-    .map((item) => ({
-      id: item.id,
-      status: item.status,
-      first: item.name,
-      second: utilFormatDuration(item.startsAt, item.workhour),
-      third: `${item.hourlyPay.toLocaleString()}원`,
-    }))
-    .filter((item) => item.status !== 'canceled')
+  const tableData: TableData[] = data.map((item) => ({
+    id: item.id,
+    status: item.status,
+    first: item.name,
+    second: utilFormatDuration(item.startsAt, item.workhour),
+    third: `${item.hourlyPay.toLocaleString()}원`,
+  }))
 
   if (!(tableData.length > 0)) return <UiNoTableData userType="employee" />
   return (
@@ -88,15 +86,13 @@ function ApplicantListTable({
   paginationElement,
   page,
 }: ApplicantListTableProps) {
-  const tableData: TableData[] = data
-    .map((item) => ({
-      id: item.id,
-      status: item.status,
-      first: item.name,
-      second: item.description,
-      third: item.phone && utilFormatPhone(item.phone),
-    }))
-    .filter((item) => item.status !== 'canceled')
+  const tableData: TableData[] = data.map((item) => ({
+    id: item.id,
+    status: item.status,
+    first: item.name,
+    second: item.description,
+    third: item.phone && utilFormatPhone(item.phone),
+  }))
 
   if (!(tableData.length > 0)) {
     return <UiNoTableData userType="employer" checkPage={page !== 1} />

--- a/libs/shared/table/ui/ui-table-composition/ui-table-body-status-chip.module.scss
+++ b/libs/shared/table/ui/ui-table-composition/ui-table-body-status-chip.module.scss
@@ -16,7 +16,8 @@
     color: utils.$blue-brt1;
   }
 
-  &.rejected {
+  &.rejected,
+  &.canceled {
     background-color: utils.$red-brt4;
     color: utils.$red-brt1;
   }

--- a/libs/shared/table/ui/ui-table-composition/ui-table-body-status-chip.tsx
+++ b/libs/shared/table/ui/ui-table-composition/ui-table-body-status-chip.tsx
@@ -12,7 +12,10 @@ export default function UiTableBodyStatusChip({ status }: { status: Status }) {
       return <div className={cx('chip', { [status]: status })}>승인완료</div>
     case 'rejected':
       return <div className={cx('chip', { [status]: status })}>거절</div>
-    default:
+    case 'canceled':
+      return <div className={cx('chip', { [status]: status })}>취소</div>
+    case 'pending':
       return <div className={cx('chip', { [status]: status })}>대기중</div>
+    default:
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- FIX : 버그 수정

## 설명

사장 가게 공고 상세 페이지 로딩 처리 & 테이블 canceled 버그 픽스

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #156 

### Key Changes

- 도메인/클라이언트 컴포넌트에 로딩 적용
- 테이블 상태 변경 후 토스트 UI 구현
- 테이블 canceled 목록에 안뜨는 버그 픽스

![DemoCreatorRec_2023-07-19-15-30-26](https://github.com/codeit-bootcamp-frontend/0-the-julge-young-developers/assets/125791542/0e5e8501-e1cd-4ac2-be8c-6197df4ce631)


### How it Works

- 신청자를 승인했을 때 토스트와 동일하게 3초 뒤에 router.push('/my-shop')으로 보내도록 했습니다 (더 좋은 의견 있으면 부탁드려요)
- canceled 상태도 테이블에 보이도록 했고, 취소와 같이 red 색상으로 처리했습니다.


### To Reviewers

- 애매하거나 같이 얘기해보고 싶은 부분
