### PR TITLE
✅ 사장님 페이지 - 에러처리

### DIFF
--- a/libs/my-shop-notice/feature/my-shop-notice-edit-button.tsx
+++ b/libs/my-shop-notice/feature/my-shop-notice-edit-button.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-/* eslint-disable no-unused-vars */
 import { useState } from 'react'
+
+import { useRouter } from 'next/navigation'
 
 import RegisterNoticeModal from '@/libs/my-shop/feature/my-notice/register-notice-modal'
 import { ActiveOutlineBtn } from '@/libs/shared/click-btns/feature/click-btns'
+import { ConfirmDialog } from '@/libs/shared/dialog/feature/dialog'
 import ToastContainer from '@/libs/shared/toast/feature/toast-container'
 
 import { MyShopNoticeEditButtonProps } from '../type-my-shop-notice'
@@ -17,6 +17,31 @@ export default function MyShopNoticeEditButton({
   const [shownEditModal, setShownEditModal] = useState(false)
   const [showModal, setShowModal] = useState<boolean>(false)
   const [showToast, setShowToast] = useState<boolean>(false)
+  const [openErrorDialog, setOpenErrorDialog] = useState<boolean>(false)
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const router = useRouter()
+
+  const handleClickShowErrorDialog = (text: string) => {
+    setErrorMessage(text)
+    setOpenErrorDialog(true)
+    switch (text) {
+      case '로그인이 필요합니다':
+        router.push('/signin')
+        break
+      case '공고를 수정할 권한이 없습니다':
+        router.push('/')
+        break
+      case '존재하지 않는 가게입니다' || '존재하지 않는 공고입니다':
+        router.push('/my-shop')
+        break
+      case '마감된 공고는 수정할 수 없습니다':
+        setShownEditModal(false)
+        break
+      default:
+        break
+    }
+  }
+
   const handleClickButton = () => {
     setShownEditModal((prev) => !prev)
 
@@ -43,12 +68,19 @@ export default function MyShopNoticeEditButton({
           showModal={showModal}
           notice={notice}
           onClickShowToast={() => setShowToast(true)}
+          onClickShowErrorDialog={handleClickShowErrorDialog}
         />
       )}
       {showToast && (
         <ToastContainer onShow={() => setShowToast(false)}>
           편집을 완료했어요
         </ToastContainer>
+      )}
+      {openErrorDialog && (
+        <ConfirmDialog
+          text={errorMessage || '요청에 실패했습니다.'}
+          onConfirm={() => setOpenErrorDialog(false)}
+        />
       )}
     </>
   )

--- a/libs/my-shop/data-access/data-access-send-notice-request.tsx
+++ b/libs/my-shop/data-access/data-access-send-notice-request.tsx
@@ -11,7 +11,7 @@ export async function sendNoticeRequest({
   workhour,
   description,
   noticeId,
-}: RegisterdShopNoticeProps): Promise<boolean> {
+}: RegisterdShopNoticeProps): Promise<[boolean, string]> {
   if (noticeId) {
     const response = await updateShopNotice(shopId, noticeId, {
       hourlyPay,
@@ -19,10 +19,13 @@ export async function sendNoticeRequest({
       workhour,
       description,
     })
-    if (typeof response !== 'string' && !(response instanceof Error)) {
-      return true
+    if (response instanceof Error) {
+      throw response
+    } else if (typeof response == 'string') {
+      return [true, response]
+    } else {
+      return [false, '']
     }
-    return false
   }
   const response = await registerShopNotice({
     shopId,
@@ -31,10 +34,12 @@ export async function sendNoticeRequest({
     workhour,
     description,
   })
-  console.log(response)
 
-  if (typeof response !== 'string' && !(response instanceof Error)) {
-    return true
+  if (response instanceof Error) {
+    throw response
+  } else if (typeof response == 'string') {
+    return [true, response]
+  } else {
+    return [false, '']
   }
-  return false
 }

--- a/libs/my-shop/feature/my-notice/register-notice-btn.tsx
+++ b/libs/my-shop/feature/my-notice/register-notice-btn.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from 'react'
 
+import { useRouter } from 'next/navigation'
+
 import { ActiveBtn } from '@/libs/shared/click-btns/feature/click-btns'
+import { ConfirmDialog } from '@/libs/shared/dialog/feature/dialog'
 import { useMediaQuery } from '@/libs/shared/shared/util/useMediaQuery'
 import ToastContainer from '@/libs/shared/toast/feature/toast-container'
 
@@ -12,7 +15,26 @@ export default function RegisterNoticeBtn() {
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [showModal, setShowModal] = useState<boolean>(false)
   const [showToast, setShowToast] = useState<boolean>(false)
-
+  const [openErrorDialog, setOpenErrorDialog] = useState<boolean>(false)
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const router = useRouter()
+  const handleClickShowErrorDialog = (text: string) => {
+    setErrorMessage(text)
+    setOpenErrorDialog(true)
+    switch (text) {
+      case '로그인이 필요합니다':
+        router.push('/signin')
+        break
+      case '공고를 게시할 권한이 없습니다':
+        router.push('/')
+        break
+      case '존재하지 않는 가게입니다':
+        router.push('/my-shop')
+        break
+      default:
+        break
+    }
+  }
   const isMobile = useMediaQuery('(max-width: 768px)')
   const handleClickToggleModal = () => {
     setOpenModal(!openModal)
@@ -35,12 +57,20 @@ export default function RegisterNoticeBtn() {
           showModal={showModal}
           onClickToggelModal={handleClickToggleModal}
           onClickShowToast={() => setShowToast(true)}
+          onClickShowErrorDialog={handleClickShowErrorDialog}
         />
       )}
       {showToast && (
         <ToastContainer onShow={() => setShowToast(false)}>
           등록을 완료했어요
         </ToastContainer>
+      )}
+
+      {openErrorDialog && (
+        <ConfirmDialog
+          text={errorMessage || '요청에 실패했습니다.'}
+          onConfirm={() => setOpenErrorDialog(false)}
+        />
       )}
     </div>
   )

--- a/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
+++ b/libs/my-shop/feature/my-notice/register-notice-default-content.tsx
@@ -29,11 +29,13 @@ export default function RegisterNoticeDefaultContent({
   onClickToggelModal,
   notice,
   onClickShowToast,
+  onClickShowErrorDialog,
 }: {
   showModal: boolean
   onClickToggelModal: () => void
   notice?: NoticeEditData
   onClickShowToast: () => void
+  onClickShowErrorDialog: (text: string) => void
 }) {
   const [isLoading, setISLoading] = useState(false)
   const router = useRouter()
@@ -56,7 +58,7 @@ export default function RegisterNoticeDefaultContent({
       return
     }
     setISLoading(true)
-    const isSuccess = await sendNoticeRequest({
+    const [isError, errorMessage] = await sendNoticeRequest({
       shopId: `${sid}`,
       hourlyPay: hourlyWage as number,
       startsAt: startsAt.toISOString(),
@@ -64,15 +66,14 @@ export default function RegisterNoticeDefaultContent({
       description,
       noticeId: notice ? notice.noticeId : undefined,
     })
-    console.log(isSuccess)
-    if (isSuccess) {
+    if (!isError) {
       setISLoading(false)
       onClickToggelModal()
       onClickShowToast()
       router.refresh()
     } else {
       setISLoading(false)
-      // 실패의 경우 처리
+      onClickShowErrorDialog(errorMessage)
     }
   }
 

--- a/libs/my-shop/feature/my-notice/register-notice-funnel-content.tsx
+++ b/libs/my-shop/feature/my-notice/register-notice-funnel-content.tsx
@@ -29,10 +29,12 @@ export default function RegisterJobPostingFunnelContent({
   onClickToggelModal,
   notice,
   onClickShowToast,
+  onClickShowErrorDialog,
 }: {
   onClickToggelModal: () => void
   notice?: NoticeEditData
   onClickShowToast: () => void
+  onClickShowErrorDialog: (text: string) => void
 }) {
   const [funnel, setFunnel] = useState<
     'hourlyWage' | 'startsAt' | 'workhour' | 'description'
@@ -90,15 +92,13 @@ export default function RegisterJobPostingFunnelContent({
     } else if (funnel === 'workhour') {
       setFunnel('description')
     } else if (funnel === 'description') {
-      // api
-
       e.preventDefault()
       const sid = getCookie('sid')
       if (!startsAt) {
         return
       }
       setISLoading(true)
-      const isSuccess = await sendNoticeRequest({
+      const [isError, errorMessage] = await sendNoticeRequest({
         shopId: `${sid}`,
         hourlyPay: hourlyWage as number,
         startsAt: startsAt.toISOString(),
@@ -106,7 +106,7 @@ export default function RegisterJobPostingFunnelContent({
         description,
         noticeId: notice ? notice.noticeId : undefined,
       })
-      if (isSuccess) {
+      if (!isError) {
         setISLoading(false)
         onClickToggelModal()
         onClickShowToast() // 토스트 띄우기
@@ -114,6 +114,7 @@ export default function RegisterJobPostingFunnelContent({
       } else {
         setISLoading(false)
         // 실패의 경우 처리
+        onClickShowErrorDialog(errorMessage)
       }
     }
 

--- a/libs/my-shop/feature/my-notice/register-notice-modal.tsx
+++ b/libs/my-shop/feature/my-notice/register-notice-modal.tsx
@@ -12,11 +12,13 @@ export default function RegisterNoticeModal({
   onClickToggelModal,
   notice,
   onClickShowToast,
+  onClickShowErrorDialog,
 }: {
   showModal: boolean
   onClickToggelModal: () => void
   notice?: NoticeEditData
   onClickShowToast: () => void
+  onClickShowErrorDialog: (text: string) => void
 }) {
   const isMobile = useMediaQuery('(max-width: 768px)')
 
@@ -27,6 +29,7 @@ export default function RegisterNoticeModal({
           onClickToggelModal={onClickToggelModal}
           notice={notice}
           onClickShowToast={onClickShowToast}
+          onClickShowErrorDialog={onClickShowErrorDialog}
         />
       ) : (
         <RegisterNoticeDefaultContent
@@ -34,6 +37,7 @@ export default function RegisterNoticeModal({
           showModal={showModal}
           notice={notice}
           onClickShowToast={onClickShowToast}
+          onClickShowErrorDialog={onClickShowErrorDialog}
         />
       )}
     </ModalPortalWrapper>

--- a/libs/my-shop/feature/my-shop/register-shop-btn.tsx
+++ b/libs/my-shop/feature/my-shop/register-shop-btn.tsx
@@ -5,6 +5,8 @@
 /* eslint-disable no-unused-vars */
 import { useState } from 'react'
 
+import { useRouter } from 'next/navigation'
+
 import { ActiveBtn } from '@/libs/shared/click-btns/feature/click-btns'
 import { ConfirmDialog } from '@/libs/shared/dialog/feature/dialog'
 import { useMediaQuery } from '@/libs/shared/shared/util/useMediaQuery'
@@ -18,10 +20,20 @@ export default function RegisterShopBtn() {
   const [openErrorDialog, setOpenErrorDialog] = useState<boolean>(false)
   const [errorMessage, setErrorMessage] = useState<string>('')
   const [showToast, setShowToast] = useState(false)
-
+  const router = useRouter()
   const handleClickShowErrorDialog = (text: string) => {
     setErrorMessage(text)
     setOpenErrorDialog(true)
+    switch (text) {
+      case '로그인이 필요합니다':
+        router.push('/signin')
+        break
+      case '이미 등록한 가게가 있습니다':
+        router.push('/')
+        break
+      default:
+        break
+    }
   }
 
   const handleClickToggleModal = () => {
@@ -40,19 +52,20 @@ export default function RegisterShopBtn() {
         <RegisterShopModal
           onClickToggelModal={handleClickToggleModal}
           onClickShowToast={() => setShowToast(true)}
-          // handleClickShowErrorDialog={handleClickShowErrorDialog}
+          onClickShowErrorDialog={handleClickShowErrorDialog}
         />
       )}
-      {/* {openErrorDialog && (
-        <ConfirmDialog
-          text={errorMessage || '요청에 실패했습니다.'}
-          onConfirm={() => setOpenErrorDialog(false)}
-        />
-      )} */}
+
       {showToast && (
         <ToastContainer onShow={() => setShowToast(false)}>
           등록을 완료했어요
         </ToastContainer>
+      )}
+      {openErrorDialog && (
+        <ConfirmDialog
+          text={errorMessage || '요청에 실패했습니다.'}
+          onConfirm={() => setOpenErrorDialog(false)}
+        />
       )}
     </div>
   )

--- a/libs/my-shop/feature/my-shop/register-shop-modal-default-contnet.tsx
+++ b/libs/my-shop/feature/my-shop/register-shop-modal-default-contnet.tsx
@@ -30,10 +30,12 @@ export default function RegisterShopModalDefaultContent({
   shop,
   onClickToggelModal,
   onClickShowToast,
+  onClickShowErrorDialog,
 }: {
   shop?: Shop
   onClickToggelModal: () => void
   onClickShowToast: () => void
+  onClickShowErrorDialog: (text: string) => void
 }) {
   const [isLoading, setISLoading] = useState(false)
   const router = useRouter()
@@ -59,7 +61,7 @@ export default function RegisterShopModalDefaultContent({
   const handleSubmit = async (e: MouseEvent<HTMLFormElement>) => {
     e.preventDefault()
     setISLoading(true)
-    const isError = await sendRegisterShopRequest(
+    const [isError, errorMessage] = await sendRegisterShopRequest(
       shop,
       shopName,
       category,
@@ -76,7 +78,7 @@ export default function RegisterShopModalDefaultContent({
       router.refresh()
     } else {
       setISLoading(false)
-      // 실패의 경우 처리
+      onClickShowErrorDialog(errorMessage)
     }
   }
 

--- a/libs/my-shop/feature/my-shop/register-shop-modal-funnel-content.tsx
+++ b/libs/my-shop/feature/my-shop/register-shop-modal-funnel-content.tsx
@@ -1,8 +1,3 @@
-/* eslint-disable no-unused-vars */
-
-/* eslint-disable lines-around-directive */
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
 'use client'
 
 import { ChangeEvent, MouseEvent, useEffect, useState } from 'react'
@@ -32,26 +27,18 @@ import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-s
 
 import styles from './register-shop-modal-funnel-content.module.scss'
 
-/* eslint-disable no-unused-vars */
-
-/* eslint-disable lines-around-directive */
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-/* eslint-disable no-unused-vars */
-/* eslint-disable lines-around-directive */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 const cx = classNames.bind(styles)
 
 export default function RegisterShopModalFunnelContent({
   shop,
   onClickToggelModal,
   onClickShowToast,
+  onClickShowErrorDialog,
 }: {
   shop?: Shop
   onClickToggelModal: () => void
   onClickShowToast: () => void
+  onClickShowErrorDialog: (text: string) => void
 }) {
   const [isLoading, setISLoading] = useState(false)
   const router = useRouter()
@@ -146,8 +133,7 @@ export default function RegisterShopModalFunnelContent({
       router.refresh()
     } else {
       setISLoading(false)
-      // 실패의 경우 처리
-      // if
+      onClickShowErrorDialog(errorMessage)
     }
   }
 

--- a/libs/my-shop/feature/my-shop/register-shop-modal.tsx
+++ b/libs/my-shop/feature/my-shop/register-shop-modal.tsx
@@ -16,10 +16,12 @@ export default function RegisterShopModal({
   shop,
   onClickToggelModal,
   onClickShowToast,
+  onClickShowErrorDialog,
 }: {
   shop?: Shop
   onClickToggelModal: () => void
   onClickShowToast: () => void
+  onClickShowErrorDialog: (text: string) => void
 }) {
   const isMobile = useMediaQuery('(max-width: 768px)')
   return (
@@ -29,12 +31,14 @@ export default function RegisterShopModal({
           onClickToggelModal={onClickToggelModal}
           shop={shop}
           onClickShowToast={onClickShowToast}
+          onClickShowErrorDialog={onClickShowErrorDialog}
         />
       ) : (
         <RegisterShopModalDefaultContent
           onClickToggelModal={onClickToggelModal}
           shop={shop}
           onClickShowToast={onClickShowToast}
+          onClickShowErrorDialog={onClickShowErrorDialog}
         />
       )}
     </ModalPortalWrapper>

--- a/libs/my-shop/ui/ui-my-shop-detail/ui-my-shop-detail-button.tsx
+++ b/libs/my-shop/ui/ui-my-shop-detail/ui-my-shop-detail-button.tsx
@@ -41,7 +41,7 @@ export default function UiMyShopDetailButton({ shop }: { shop: Shop }) {
       case '로그인이 필요합니다':
         router.push('/signin')
         break
-      case '공고를 게시할 권한이 없습니다':
+      case '공고를 게시할 권한이 없습니다' || '가게를 수정할 권한이 없습니다':
         router.push('/')
         break
       case '존재하지 않는 가게입니다':

--- a/libs/my-shop/ui/ui-my-shop-detail/ui-my-shop-detail-button.tsx
+++ b/libs/my-shop/ui/ui-my-shop-detail/ui-my-shop-detail-button.tsx
@@ -7,6 +7,8 @@ import { useEffect, useState } from 'react'
 
 import classNames from 'classnames/bind'
 
+import { useRouter } from 'next/navigation'
+
 import RegisterNoticeModal from '@/libs/my-shop/feature/my-notice/register-notice-modal'
 import RegisterShopModal from '@/libs/my-shop/feature/my-shop/register-shop-modal'
 import { Shop } from '@/libs/my-shop/type-my-shop'
@@ -14,6 +16,7 @@ import {
   ActiveBtn,
   ActiveOutlineBtn,
 } from '@/libs/shared/click-btns/feature/click-btns'
+import { ConfirmDialog } from '@/libs/shared/dialog/feature/dialog'
 import ToastContainer from '@/libs/shared/toast/feature/toast-container'
 
 import styles from './ui-my-shop-detail-button.module.scss'
@@ -25,6 +28,29 @@ export default function UiMyShopDetailButton({ shop }: { shop: Shop }) {
   const [showModal, setShowModal] = useState<boolean>(false)
   const [showEditToast, setShowEditToast] = useState<boolean>(false)
   const [showRegisterToast, setShowRegisterToast] = useState<boolean>(false)
+  const [openErrorDialog, setOpenErrorDialog] = useState<boolean>(false)
+  const [errorMessage, setErrorMessage] = useState<string>('')
+
+  const router = useRouter()
+  const handleClickShowErrorDialog = (text: string) => {
+    console.log(text)
+    setErrorMessage(text)
+    setOpenErrorDialog(true)
+
+    switch (text) {
+      case '로그인이 필요합니다':
+        router.push('/signin')
+        break
+      case '공고를 게시할 권한이 없습니다':
+        router.push('/')
+        break
+      case '존재하지 않는 가게입니다':
+        router.push('/my-shop')
+        break
+      default:
+        break
+    }
+  }
 
   useEffect(() => {
     console.log(showEditToast)
@@ -64,6 +90,7 @@ export default function UiMyShopDetailButton({ shop }: { shop: Shop }) {
           onClickShowToast={() =>
             shop ? setShowEditToast(true) : setShowRegisterToast(true)
           }
+          onClickShowErrorDialog={handleClickShowErrorDialog}
         />
       )}
       {openNoticeModal && (
@@ -71,6 +98,7 @@ export default function UiMyShopDetailButton({ shop }: { shop: Shop }) {
           onClickToggelModal={handleClickToggleNoticeModal}
           showModal={showModal}
           onClickShowToast={() => setShowRegisterToast(true)}
+          onClickShowErrorDialog={handleClickShowErrorDialog}
         />
       )}
       <div>
@@ -83,6 +111,13 @@ export default function UiMyShopDetailButton({ shop }: { shop: Shop }) {
           <ToastContainer onShow={() => setShowRegisterToast(false)}>
             등록을 완료했어요
           </ToastContainer>
+        )}
+
+        {openErrorDialog && (
+          <ConfirmDialog
+            text={errorMessage || '요청에 실패했습니다.'}
+            onConfirm={() => setOpenErrorDialog(false)}
+          />
         )}
       </div>
     </>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선


## 설명
에러에 따른 routing 처리 및 모달 띄우는 기능 구현했습니다.

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->
close #185 


### Key Changes
- 가게 및 공고 등록, 수정 에러 처리
   - request form 안맞는 경우 처리
   - 권한, id 에러 등 처리


### How it Works

- 로그인 필요, 존재하지 않는 가게 or 공고, 수정 및 등록 권한 등의 에러는 `/` or `my-shop` 등으로 routing 처리
- form 관련 에러는 다시 입력하도록 모달 띄우기
- 이외의 알 수 없는 에러는 throw error


### To Reviewers

- form에 맞지 않는 데이터 (최저 시급 안맞추는 등)을 넣었을 때 에러 모달이 뜨는데, 이때 input의 값 초기화 시킬지 말지 고민입니다. (하려면 꽤 거릴 듯..🤣)
