### PR TITLE
Gnb 서버 컴포넌트로 랩핑 작업 => 초기 렌더링 안 보이던 문제 해결 && noti api 수정 (모달창 open시 요청 막기) 

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,4 +1,4 @@
-import Gnb from '@/libs/gnb/feature/gnb'
+import GnbServer from '@/libs/gnb/feature/gnb-server'
 
 export default async function NoticeDetailLayout({
   children,
@@ -7,7 +7,7 @@ export default async function NoticeDetailLayout({
 }) {
   return (
     <>
-      <Gnb />
+      <GnbServer />
       {children}
       <div id="loader-portal" />
       <div id="btn-portal" />

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,5 +1,5 @@
 import UiFooter from '@/libs/footer/ui/ui-footer/ui-footer'
-import Gnb from '@/libs/gnb/feature/gnb'
+import GnbServer from '@/libs/gnb/feature/gnb-server'
 
 export default async function MainLayout({
   children,
@@ -8,7 +8,7 @@ export default async function MainLayout({
 }) {
   return (
     <>
-      <Gnb />
+      <GnbServer />
       {children}
       <UiFooter />
     </>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -22,8 +22,10 @@ export default async function Home({
   const response = await getNotices({ limit, offset })
   if (response instanceof Error) {
     // 알 수 없는 에러 처리
+    throw new Error()
   } else if (typeof response === 'string') {
     // 에러 메시지에 맞게 처리
+    throw new Error(response)
   } else {
     // response 데이터 가공
     const { items, count } = response

--- a/app/(main)/search/page.tsx
+++ b/app/(main)/search/page.tsx
@@ -25,8 +25,10 @@ export default async function SearchPage({
   })
   if (response instanceof Error) {
     // 알 수 없는 에러 처리
+    throw new Error()
   } else if (typeof response === 'string') {
     // 에러 메시지에 맞게 처리
+    throw new Error(response)
   } else {
     // response 데이터 가공
     const { items, count } = response

--- a/libs/gnb/feature/gnb-server.tsx
+++ b/libs/gnb/feature/gnb-server.tsx
@@ -1,0 +1,39 @@
+import { cookies } from 'next/headers'
+
+import { getUserInfo } from '@/libs/shared/api/data-access/request/userRequest'
+
+import Gnb from './gnb'
+
+export const revalidate = 3600
+export default async function GnbServer() {
+  const cookieInstance = cookies()
+  const userId = cookieInstance.get('uid')?.value
+
+  let userType
+  let sid
+
+  if (!userId) {
+    userType = 'guest'
+  } else {
+    const userInfo = await getUserInfo(userId)
+
+    if (userInfo instanceof Error) {
+      // 알 수 없는 에러 처리
+    } else if (typeof userInfo === 'string') {
+      // 에러 메시지에 맞게 처리
+    } else {
+      // res 데이터 가공
+      userType = userInfo.item.type
+      if (userType === 'employer' && userInfo.item.shop) {
+        sid = userInfo.item.shop.item.id
+      }
+    }
+  }
+
+  return (
+    <Gnb
+      userType={userType as 'guest' | 'employee' | 'employer' | undefined}
+      sid={sid}
+    />
+  )
+}

--- a/libs/gnb/feature/gnb-server.tsx
+++ b/libs/gnb/feature/gnb-server.tsx
@@ -19,8 +19,10 @@ export default async function GnbServer() {
 
     if (userInfo instanceof Error) {
       // 알 수 없는 에러 처리
+      throw new Error()
     } else if (typeof userInfo === 'string') {
       // 에러 메시지에 맞게 처리
+      throw new Error(userInfo)
     } else {
       // res 데이터 가공
       userType = userInfo.item.type

--- a/libs/gnb/feature/gnb.tsx
+++ b/libs/gnb/feature/gnb.tsx
@@ -2,56 +2,34 @@
 
 import { useEffect, useState } from 'react'
 
-import { getCookie, setCookie } from 'cookies-next'
+import { setCookie } from 'cookies-next'
 
 import { useRouter } from 'next/navigation'
 
 import Searchbar from '@/libs/gnb/feature/searchbar'
 import UiGnb from '@/libs/gnb/ui/ui-gnb/ui-gnb'
-import { getUserInfo } from '@/libs/shared/api/data-access/request/userRequest'
 
-export default function Gnb() {
+interface GnbProps {
+  userType?: 'guest' | 'employee' | 'employer'
+  sid?: string
+}
+
+export default function Gnb({ userType, sid }: GnbProps) {
   const [hasNotification, setHasNotification] = useState(false)
-  const [userType, setUserType] = useState<
-    'employee' | 'employer' | 'guest' | null
-  >(null)
+
   const router = useRouter()
-  const userId = getCookie('uid') as string
 
   const handleCheckNotification = () => {
     setHasNotification(true)
   }
 
-  const getUserType = async (uid: string) => {
-    const userInfo = await getUserInfo(uid)
-    if (userInfo instanceof Error) {
-      // 알 수 없는 에러 처리
-    } else if (typeof userInfo === 'string') {
-      // 에러 메시지에 맞게 처리
-    } else {
-      // res 데이터 가공
-      setUserType(userInfo.item.type)
-      if (userInfo.item.type === 'employer' && userInfo.item.shop) {
-        setCookie('sid', userInfo.item.shop.item.id)
-      }
-    }
-  }
-
-  useEffect(() => {
-    const fetchUserType = async () => {
-      if (!userId) {
-        setUserType('guest')
-      } else {
-        await getUserType(userId)
-      }
-    }
-
-    fetchUserType()
-  }, [userId])
-
   const handleClickMovePage = (pathname?: string) => {
     router.push(`/${pathname}`)
   }
+
+  useEffect(() => {
+    setCookie('sid', sid)
+  }, [sid])
 
   return (
     <UiGnb

--- a/libs/gnb/feature/gnb.tsx
+++ b/libs/gnb/feature/gnb.tsx
@@ -9,12 +9,12 @@ import { useRouter } from 'next/navigation'
 import Searchbar from '@/libs/gnb/feature/searchbar'
 import UiGnb from '@/libs/gnb/ui/ui-gnb/ui-gnb'
 
-interface GnbProps {
+interface GnbClientProps {
   userType?: 'guest' | 'employee' | 'employer'
   sid?: string
 }
 
-export default function Gnb({ userType, sid }: GnbProps) {
+export default function Gnb({ userType, sid }: GnbClientProps) {
   const [hasNotification, setHasNotification] = useState(false)
 
   const router = useRouter()

--- a/libs/gnb/feature/noti-button.tsx
+++ b/libs/gnb/feature/noti-button.tsx
@@ -35,6 +35,7 @@ export default function NotiButton({
   const userId = getCookie('uid') as string
 
   const handleClickNoti = async () => {
+    if (isModalOpen) return
     const response = await getUserAlertsList(userId)
     if (response instanceof Error) {
       // 알 수 없는 에러 처리

--- a/libs/gnb/type-gnb.d.ts
+++ b/libs/gnb/type-gnb.d.ts
@@ -1,5 +1,5 @@
 interface GnbProps {
-  userType: 'employee' | 'employer' | 'guest' | null
+  userType?: 'employee' | 'employer' | 'guest'
   hasNotification: boolean
   searchbarElement: React.ReactNode
   handleClickMovePage: (pathname?: string) => void


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FEAT : 새로운 기능 추가 및 개선
- FIX : 버그 수정
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정

## 설명

- Gnb를 서버 컴포넌트로 감싸서 get api를 서버에서 쏘도록 구조를 변경했습니다. 
- 초기 렌더링 시 안 보이던 문제 해결했습니다. 
- noti 모달이 열려있을 때 아이콘을 클릭하면 api 요청되던 걸 막았습니다.

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #189 


### Key Changes

- 어떤 작업을 했는지


### How it Works

- 간단한 로직 설명


### To Reviewers

- 애매하거나 같이 얘기해보고 싶은 부분
