### PR TITLE
Hotfix 사장님 페이지 - 가게 상세 페이지 버그 수정

### DIFF
--- a/app/(main)/my-shop/page.tsx
+++ b/app/(main)/my-shop/page.tsx
@@ -21,6 +21,9 @@ export default async function MyShopPage() {
   } else if (typeof userInfo === 'string') {
     throw new Error(userInfo)
   } else {
+    if (userInfo.item.type === 'employee') {
+      redirect('/')
+    }
     shopId = userInfo.item.shop?.item.id
   }
 

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -13,31 +13,35 @@ import UnregisteredMyNotice from './unregistered-notice'
 export default function MyNoticeList({ shopId }: { shopId: string }) {
   const [offset, setOffset] = useState<number>(0)
   const [noticeData, setNoticeData] = useState<ShopNoticesData | undefined>()
+  const [isLoading, setIsLoading] = useState(true)
+
   const [count, setCount] = useState(0)
-  const [isLoading, setIsLoading] = useState(false)
+
+  const [isNoticeListLoading, setIsNoticeListLodaing] = useState(false)
   const [inView, setInView] = useState(false)
   const lastItemRef = useRef<HTMLDivElement>(null)
 
   async function fetchNotices() {
-    setIsLoading(true)
+    setIsNoticeListLodaing(true)
     const response = await getShopNotices({
       shopId,
       offset,
       limit: 3,
     })
-    setIsLoading(false)
+    setIsNoticeListLodaing(false)
+    console.log(response)
 
     if (response instanceof Error) {
       // 알 수 없는 에러 처리
       return false
     }
     if (typeof response === 'string') {
-      // 에러 메시지에 따른 에러 처리
       return false
     }
+
     const newNoticeData = response
     const newCount = newNoticeData.count
-    if (offset > count || isLoading) {
+    if (offset > count || isNoticeListLoading) {
       return
     }
     if (newNoticeData.items && newNoticeData.items.length > 0) {
@@ -53,8 +57,11 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
       setOffset((prev) => prev + 3)
       setInView(false)
     }
+    setIsLoading(false)
+
     return true
   }
+  console.log(isLoading)
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -73,23 +80,10 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
   }, [])
 
   useEffect(() => {
-    if (!isLoading) {
+    if (!isNoticeListLoading) {
       fetchNotices()
     }
   }, [inView])
-
-  if (!noticeData) {
-    return (
-      <UiSimpleLayout
-        title="등록한 공고"
-        titleAlign="start"
-        titleSize={28}
-        gap={24}
-      >
-        <UiLoading />
-      </UiSimpleLayout>
-    )
-  }
 
   return (
     <div>
@@ -99,12 +93,13 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
         titleSize={28}
         gap={24}
       >
-        {count === 0 ? (
-          <UnregisteredMyNotice />
-        ) : (
+        {isLoading && <UiLoading />}
+        {!isLoading && !noticeData && <UnregisteredMyNotice />}
+
+        {!isLoading && noticeData && count !== 0 && (
           <>
             <NoticeCardList shopId={shopId} notices={noticeData} />
-            {isLoading && <UiLoading />}
+            {isNoticeListLoading && <UiLoading />}
           </>
         )}
       </UiSimpleLayout>

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -29,7 +29,6 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
       limit: 3,
     })
     setIsNoticeListLodaing(false)
-    console.log(response)
 
     if (response instanceof Error) {
       // 알 수 없는 에러 처리
@@ -61,7 +60,6 @@ export default function MyNoticeList({ shopId }: { shopId: string }) {
 
     return true
   }
-  console.log(isLoading)
 
   useEffect(() => {
     const observer = new IntersectionObserver(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FIX : 버그 수정
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정


## 설명
사장님 페이지 가게 상세의 가게 등록 하기 및 공고 불러오기 버그 수정했습니다.


### 이슈 번호
close #190
<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->



### Key Changes

가게 등록 -> 성공 시, 모달 안닫힘, 성공 여부 안보여짐
등록한 공고 없을 때 무한 로딩 발생
사장님 페이지 (my-shop)을 알바생일때 들어오지 못하도록 수정


### How it Works
- 가게 등록 성공 시 모달 닫히고, 등록 여부가 보입니다.
- 등록한 공고가 없을 때 잠깐 로딩이 생겼다가 공고 등록하기 컴포넌트가 보입니다.
- 알바생이 `my-shop` 접근 시 root로 이동합니다.

