### PR TITLE
🚑 무한 스크롤링 스크롤 하지 않을 때 IO가 인식 못하는 버그 픽스

### DIFF
--- a/libs/my-shop/feature/my-notice/my-notice-list-added-scrolling.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list-added-scrolling.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { getShopNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
+import { ShopNoticesData } from '@/libs/shared/api/types/type-notice'
+import UiLoading from '@/libs/shared/loading/ui/ui-loading'
+import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
+
+import NoticeCardList from './notice-card-list'
+
+const INITIAL_CARDS = 6
+const CARDS_PER_LINE = 3
+export default function MyNoticeListAddedScrolling({
+  shopId,
+  initialNoticeData,
+}: {
+  shopId: string
+  initialNoticeData: ShopNoticesData
+}) {
+  const [offset, setOffset] = useState<number>(INITIAL_CARDS)
+  const [noticeData, setNoticeData] =
+    useState<ShopNoticesData>(initialNoticeData)
+  const [hasNext, setHasNext] = useState(initialNoticeData.hasNext)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isInitialLoading, setIsInitialLoading] = useState(true)
+  const [inView, setInView] = useState(false)
+
+  const lastItemRef = useRef<HTMLDivElement>(null)
+
+  const fetchNotices = async (limit: number) => {
+    setIsLoading(true)
+    const response = await getShopNotices({
+      shopId,
+      offset,
+      limit,
+    })
+    setIsLoading(false)
+
+    if (response instanceof Error) {
+      return false
+    }
+    if (typeof response === 'string') {
+      return false
+    }
+    const newNoticeData = response
+
+    if (newNoticeData.items && newNoticeData.items.length > 0) {
+      const mergedItems = [...noticeData.items, ...newNoticeData.items]
+      newNoticeData.items = mergedItems
+      setNoticeData(newNoticeData)
+    }
+    setOffset((prev) => prev + 3)
+    setHasNext(newNoticeData.hasNext)
+  }
+
+  useEffect(() => {
+    if (!isInitialLoading && !isLoading && hasNext) {
+      fetchNotices(CARDS_PER_LINE)
+    }
+    setIsInitialLoading(false)
+  }, [inView])
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setInView(true)
+        } else {
+          setInView(false)
+        }
+      },
+      { threshold: 1 },
+    )
+    if (!lastItemRef.current) return
+    observer.observe(lastItemRef.current)
+
+    const lastItemRefBottom = lastItemRef.current.getBoundingClientRect().bottom
+    const { clientHeight, clientWidth } = document.documentElement
+    const cardHeight = clientWidth > 768 ? 312 : 171
+    if (lastItemRefBottom <= clientHeight) {
+      const limit =
+        (Math.floor((clientHeight - lastItemRefBottom) / cardHeight) + 1) *
+        CARDS_PER_LINE
+      fetchNotices(limit)
+    }
+  }, [])
+
+  return (
+    <div>
+      <UiSimpleLayout
+        title="등록한 공고"
+        titleAlign="start"
+        titleSize={28}
+        gap={24}
+      >
+        <NoticeCardList shopId={shopId} notices={noticeData} />
+        {isLoading && <UiLoading />}
+      </UiSimpleLayout>
+      <div ref={lastItemRef} style={{ height: '1px' }} />
+    </div>
+  )
+}

--- a/libs/my-shop/feature/my-notice/my-notice-list-client.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list-client.tsx
@@ -11,7 +11,7 @@ import NoticeCardList from './notice-card-list'
 
 const INITIAL_CARDS = 6
 const CARDS_PER_LINE = 3
-export default function MyNoticeListAddedScrolling({
+export default function MyNoticeListClient({
   shopId,
   initialNoticeData,
 }: {

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -1,107 +1,25 @@
-'use client'
-
-import { useEffect, useRef, useState } from 'react'
-
 import { getShopNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
-import { ShopNoticesData } from '@/libs/shared/api/types/type-notice'
-import UiLoading from '@/libs/shared/loading/ui/ui-loading'
-import UiSimpleLayout from '@/libs/shared/simple-layout/ui/ui-simple-layout/ui-simple-layout'
 
-import NoticeCardList from './notice-card-list'
+import MyNoticeListAddedScrolling from './my-notice-list-added-scrolling'
 import UnregisteredMyNotice from './unregistered-notice'
 
-export default function MyNoticeList({ shopId }: { shopId: string }) {
-  const [offset, setOffset] = useState<number>(0)
-  const [noticeData, setNoticeData] = useState<ShopNoticesData | undefined>()
-  const [isLoading, setIsLoading] = useState(true)
-
-  const [count, setCount] = useState(0)
-
-  const [isNoticeListLoading, setIsNoticeListLodaing] = useState(false)
-  const [inView, setInView] = useState(false)
-  const lastItemRef = useRef<HTMLDivElement>(null)
-
-  async function fetchNotices() {
-    setIsNoticeListLodaing(true)
-    const response = await getShopNotices({
-      shopId,
-      offset,
-      limit: 3,
-    })
-    setIsNoticeListLodaing(false)
-
-    if (response instanceof Error) {
-      // 알 수 없는 에러 처리
-      return false
-    }
-    if (typeof response === 'string') {
-      return false
-    }
-
-    const newNoticeData = response
-    const newCount = newNoticeData.count
-    if (offset > count || isNoticeListLoading) {
-      return
-    }
-    if (newNoticeData.items && newNoticeData.items.length > 0) {
-      if (noticeData) {
-        const mergedItems = [...noticeData.items, ...newNoticeData.items]
-        newNoticeData.items = mergedItems
-        setNoticeData(newNoticeData)
-      }
-
-      setNoticeData(newNoticeData)
-      setCount(newCount)
-
-      setOffset((prev) => prev + 3)
-      setInView(false)
-    }
-    setIsLoading(false)
-
-    return true
+const INITIAL_CARDS = 6
+export default async function MyNoticeList({ shopId }: { shopId: string }) {
+  const response = await getShopNotices({
+    shopId,
+    offset: 0,
+    limit: INITIAL_CARDS,
+  })
+  if (response instanceof Error) {
+    throw new Error()
+  }
+  if (typeof response === 'string') {
+    throw new Error(response)
   }
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          setInView(true)
-        } else {
-          setInView(false)
-        }
-      },
-      { threshold: 1 },
-    )
-    if (lastItemRef.current) {
-      observer.observe(lastItemRef.current)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!isNoticeListLoading) {
-      fetchNotices()
-    }
-  }, [inView])
-
-  return (
-    <div>
-      <UiSimpleLayout
-        title="등록한 공고"
-        titleAlign="start"
-        titleSize={28}
-        gap={24}
-      >
-        {isLoading && <UiLoading />}
-        {!isLoading && !noticeData && <UnregisteredMyNotice />}
-
-        {!isLoading && noticeData && count !== 0 && (
-          <>
-            <NoticeCardList shopId={shopId} notices={noticeData} />
-            {isNoticeListLoading && <UiLoading />}
-          </>
-        )}
-      </UiSimpleLayout>
-      <div ref={lastItemRef} style={{ height: '1px' }} />
-    </div>
+  return response.items.length > 0 ? (
+    <MyNoticeListAddedScrolling shopId={shopId} initialNoticeData={response} />
+  ) : (
+    <UnregisteredMyNotice />
   )
 }

--- a/libs/my-shop/feature/my-notice/my-notice-list.tsx
+++ b/libs/my-shop/feature/my-notice/my-notice-list.tsx
@@ -1,7 +1,6 @@
+import MyNoticeListClient from '@/libs/my-shop/feature/my-notice/my-notice-list-client'
+import UnregisteredMyNotice from '@/libs/my-shop/feature/my-notice/unregistered-notice'
 import { getShopNotices } from '@/libs/shared/api/data-access/request/noticeRequest'
-
-import MyNoticeListAddedScrolling from './my-notice-list-added-scrolling'
-import UnregisteredMyNotice from './unregistered-notice'
 
 const INITIAL_CARDS = 6
 export default async function MyNoticeList({ shopId }: { shopId: string }) {
@@ -18,7 +17,7 @@ export default async function MyNoticeList({ shopId }: { shopId: string }) {
   }
 
   return response.items.length > 0 ? (
-    <MyNoticeListAddedScrolling shopId={shopId} initialNoticeData={response} />
+    <MyNoticeListClient shopId={shopId} initialNoticeData={response} />
   ) : (
     <UnregisteredMyNotice />
   )


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- FIX : 버그 수정
- REFACTOR : 결과의 변경 없이 코드의 구조를 재조정

## 설명

무한 스크롤링 스크롤 하지 않을 때 IO가 인식 못하는 버그 픽스

### 이슈 번호

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

close #200 

### Key Changes


### How it Works

- 처음 6개 데이터를 서버에서 불러온 후 클라이언트 컴포넌트에 넘겨주면,
- 클라이언트에서 첫 useEffect에서 화면의 빈 부분만큼 카드 추가 fetch로 화면을 채운 후,
- IO가 스크롤에 동작하도록 변경
- 카드 fetch 결과 hasNext = false이면 추가 fetch 시도 하지 않도록 설정

### To Reviewers

- refresh 부분은 아직 해결하지 못했습니다ㅠ
